### PR TITLE
chrome.extension.getURL is deprecated

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -250,7 +250,7 @@ let ExtensionLayer = (function() {
     let self = {};
 
     self.getLocalUrl = function(url) {
-        return chrome.extension.getURL(url);
+        return chrome.runtime.getURL(url);
     };
 
     // NOTE: use cautiously!


### PR DESCRIPTION
https://developer.chrome.com/extensions/extension#method-getURL