### PR TITLE
Fix icons on store page link buttons

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2388,13 +2388,13 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	background-image:url('chrome-extension://__MSG_@@extension_id__/img/line_chart.png');
 }
 
-.steam_client_btn {
-	background-image:url('//store.steampowered.com/favicon.ico');
+.steam_client_btn i {
+	background-image:url('//steamcdn-a.akamaihd.net/store/about/icon-steamos.svg');
 }
-.pcgw_btn {
+.pcgw_btn i {
 	background-image:url('chrome-extension://__MSG_@@extension_id__/img/pcgw.png');
 }
-.cardexchange_btn {
+.cardexchange_btn i {
 	background-image:url('chrome-extension://__MSG_@@extension_id__/img/steamcardexchange.png');
 }
 


### PR DESCRIPTION
The buttons just showed the default icon.
Also the steam favicon is unfortunately not compatible. I don't know if the steam icon can be included in this repo so I just grabbed the best url I could find.