### PR TITLE
Add support for ProtonDB links to store page

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2394,6 +2394,10 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .pcgw_btn i {
 	background-image:url('chrome-extension://__MSG_@@extension_id__/img/pcgw.png');
 }
+
+.protondb_btn i {
+	background-image:url('//www.protondb.com/images/protondb-logo.svg');
+}
 .cardexchange_btn i {
 	background-image:url('chrome-extension://__MSG_@@extension_id__/img/steamcardexchange.png');
 }

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1341,6 +1341,16 @@ let AppPageClass = (function(){
                 `<a class="btnv6_blue_hoverfade btn_medium ${cls}" target="_blank" href="${url}" style="display: block; margin-bottom: 6px;">
                     <span><i class="ico16"></i>&nbsp;&nbsp; ${str}</span></a>`);
         }
+        
+        if (SyncedStorage.get("showprotondb")) {
+            let cls = "protondb_btn";
+            let url = "https://www.protondb.com/app/" + this.appid;
+            let str = Localization.str.view_in + ' ProtonDB';
+
+            linkNode.insertAdjacentHTML("afterbegin",
+                `<a class="btnv6_blue_hoverfade btn_medium ${cls}" target="_blank" href="${url}" style="display: block; margin-bottom: 6px;">
+                    <span><i class="ico16"></i>&nbsp;&nbsp; ${str}</span></a>`);
+        }
 
         if (this.hasCards && SyncedStorage.get("showsteamcardexchange")) {
             // FIXME some dlc have card category yet no card

--- a/js/core.js
+++ b/js/core.js
@@ -414,6 +414,7 @@ SyncedStorage.defaults = {
     'showoc': true,
     'showhltb': true,
     'showpcgw': true,
+    'showprotondb': false,
     'showclient': true,
     'showsteamcardexchange': false,
     'showitadlinks': true,

--- a/localization/de/strings.json
+++ b/localization/de/strings.json
@@ -363,6 +363,7 @@
         "inventory_market_text": "Marktpreise im Inventar anzeigen",
         "send_age_info": "Alter automatisch senden, wenn Altersbestätigung angefordert wird",
         "pcgw": "PCGamingWiki-Links anzeigen",
+        "protondb": "ProtonDB-Links anzeigen",
         "store_steamcards": "SteamCardExchange-Links auf Store-Seiten zeigen",
         "spamcommentregex": "Regulärer Ausdruck",
         "hide_owned_homepage": "Titel, die du besitzt, auf der Startseite",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -367,6 +367,7 @@
         "inventory_market_text": "Show Market price on inventory page",
         "send_age_info": "Automatically send age verification when requested",
         "pcgw": "Show PCGamingWiki links",
+        "protondb": "Show ProtonDB links",
         "store_steamcards": "Show SteamCardExchange links on store pages",
         "spamcommentregex": "Regular Expression string:",
         "hide_owned_homepage": "Items you own on the homepage",

--- a/options.html
+++ b/options.html
@@ -357,6 +357,10 @@
                 <label for="showpcgw" id="store_pcgw_text" data-locale-text="options.pcgw">Show PCGamingWiki links</label>
             </div>
             <div>
+                <input type="checkbox" id="showprotondb" data-setting="showprotondb">
+                <label for="showprotondb" id="store_protondb_text" data-locale-text="options.protondb">Show ProtonDB links</label>
+            </div>
+            <div>
                 <input type="checkbox" id="showwsgf" data-setting="showwsgf">
                 <label for="showwsgf" id="store_wsgf_text" data-locale-text="options.wsgf">Show WSGF (Widescreen) info</label>
             </div>


### PR DESCRIPTION
ProtonDB is a website for user submitted compatibility reports for Valve's Steam Play/Proton for Linux.