### PR TITLE
Set default for homepage_tab_last

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -476,6 +476,7 @@ SyncedStorage.defaults = {
     'showlanguagewarning': true,
     'showlanguagewarninglanguage': "English",
     'homepage_tab_selection': "remember",
+    'homepage_tab_last': null,
     'send_age_info': true,
     'html5video': true,
     'contscroll': true,


### PR DESCRIPTION
Setting it to `null` is fine, since the function that uses this settings, does a null-check.
Removes warning in console about unrecognized key