### PR TITLE
Fix sanitizing of <style> and <link> tags

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -615,7 +615,7 @@ class HTML {
             node = document.querySelector(node);
         }
 
-        node.innerHTML = DOMPurify.sanitize(html);
+        node.innerHTML = HTML._sanitize(html);
     }
 
     static adjacent(node, position, html) {
@@ -623,7 +623,7 @@ class HTML {
             node = document.querySelector(node);
         }
 
-        node.insertAdjacentHTML(position, DOMPurify.sanitize(html));
+        node.insertAdjacentHTML(position, HTML._sanitize(html));
     }
 
     static beforeBegin(node, html) {
@@ -640,6 +640,15 @@ class HTML {
 
     static afterEnd(node, html) {
         HTML.adjacent(node, "afterend", html);
+    }
+
+    static _sanitize(html) {
+        // See https://github.com/cure53/DOMPurify/issues/37
+        if (/^<(?:style|link)/.test(html)) {
+            return DOMPurify.sanitize('1' + html).substring(1);
+        } else {
+            return DOMPurify.sanitize(html);
+        }
     }
 
 }

--- a/js/core.js
+++ b/js/core.js
@@ -597,7 +597,18 @@ class ExtensionResources {
  * Default RegExp: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
  */
 (function() {
-    DOMPurify.setConfig({ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|chrome-extension|moz-extension):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i});
+    DOMPurify.setConfig({
+        ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|chrome-extension|moz-extension):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+        ADD_TAGS: ["link"]});
+
+    DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+        if (data.tagName === "link") {
+            if (node.href && !/^(?:https:\/\/steamcommunity-a\.akamaihd\.net\/|(?:moz|chrome)-extension:\/\/)/.test(node.href)) {
+                console.warn("Removed potentially malicious <link> tag with href attribute %s!", node.href);
+                return node.remove();
+            }
+        }
+    });
 })();
 
 class HTML {


### PR DESCRIPTION
Alternative to 6c2c6798cc0140028f0208b236f97191e75868f1, workaround as explained in [this issue](https://github.com/cure53/DOMPurify/issues/37).