### PR TITLE
Upgrade ProgressBar to more accurately reflect requests in progress

### DIFF
--- a/js/content/common.js
+++ b/js/content/common.js
@@ -58,9 +58,7 @@ class ProgressBar {
             value = 100;
         }
 
-        node.querySelector(".progress-value").style.width = value;
-        // TODO verify this works, shouldn't there be "%"?
-        // There's a min-width: 18px !important and "30" is interpreted as "30px"
+        node.querySelector(".progress-value").style.width = `${value}px`;
 
         if (value >= 100) {
             node.classList.add("complete");

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -160,15 +160,20 @@ let RequestData = (function(){
     let self = {};
 
     self.getJson = function(url) {
+        ProgressBar.startRequest();
+
         return new Promise(function(resolve, reject) {
             function requestHandler(state) {
                 if (state.readyState !== 4) {
                     return;
                 }
 
+                ProgressBar.finishRequest();
+
                 if (state.status === 200) {
                     resolve(JSON.parse(state.responseText));
                 } else {
+                    ProgressBar.failed(null, url, state.status, state.statusText);
                     reject(state.status);
                 }
             }
@@ -186,9 +191,6 @@ let RequestData = (function(){
         });
     };
 
-    let totalRequests = 0;
-    let processedRequests = 0;
-
     self.getHttp = function(url, settings, returnHtml) {
         settings = settings || {};
         settings.withCredentials = settings.withCredentials || false;
@@ -196,9 +198,7 @@ let RequestData = (function(){
         settings.method = settings.method || "GET";
         settings.body = settings.body || null;
 
-        totalRequests += 1;
-
-        ProgressBar.loading();
+        ProgressBar.startRequest();
 
         return new Promise(function(resolve, reject) {
 
@@ -207,8 +207,7 @@ let RequestData = (function(){
                     return;
                 }
 
-                processedRequests += 1;
-                ProgressBar.progress((processedRequests / totalRequests) * 100);
+                ProgressBar.finishRequest();
 
                 if (state.status === 200) {
                     if (returnHtml) {
@@ -1972,6 +1971,7 @@ let Common = (function(){
         ]);
 
         ProgressBar.create();
+        ProgressBar.loading();
         UpdateHandler.checkVersion();
         EnhancedSteam.addMenu();
         EnhancedSteam.addLanguageWarning();

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -253,12 +253,8 @@ let RequestData = (function(){
     return self;
 })();
 
-let ProgressBar = (function(){
-    let self = {};
-
-    let node = null;
-
-    self.create = function() {
+class ProgressBar {
+    static create() {
         if (!SyncedStorage.get("show_progressbar")) { return; }
 
         let container = document.getElementById("global_actions");
@@ -273,11 +269,10 @@ let ProgressBar = (function(){
                     </div>
                 </div>
             </div>`);
+    }
 
-        node = document.querySelector("#es_progress");
-    };
-
-    self.loading = function() {
+    static loading() {
+        let node = document.getElementById('es_progress');
         if (!node) { return; }
 
         if (Localization.str.ready) {
@@ -286,9 +281,10 @@ let ProgressBar = (function(){
 
         node.classList.remove("complete");
         node.querySelector(".progress-value").style.width = "18px";
-    };
+    }
 
-    self.progress = function(value) {
+    static progress(value) {
+        let node = document.getElementById('es_progress');
         if (!node) { return; }
 
         node.querySelector(".progress-value").style.width = value; // TODO verify this works, shouldn't there be "%"?
@@ -297,9 +293,10 @@ let ProgressBar = (function(){
             node.classList.add("complete");
             node.setAttribute("title", Localization.str.ready.ready)
         }
-    };
+    }
 
-    self.failed = function(message, url, status, error) {
+    static failed(message, url, status, error) {
+        let node = document.getElementById('es_progress');
         if (!node) { return; }
 
         node.classList.add("error");
@@ -319,10 +316,8 @@ let ProgressBar = (function(){
         }
 
         HTML.beforeEnd(nodeError.querySelector("ul"), "<li>" + message + "</li>");
-    };
-
-    return self;
-})();
+    }
+}
 
 
 let User = (function(){

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -932,10 +932,11 @@ class AppPageClass extends StorePageClass {
         HTML.afterEnd(".queue_control_button.queue_btn_ignore",
             "<div id='esi-store-wishlist-note' class='esi-note " + cssClass + "'>" + noteText + "</div>");
 
+        let that = this;
         document.addEventListener("click", function(e) {
             if (!e.target.classList.contains("esi-note")) { return; }
 
-            this.wishlistNotes.showModalDialog(document.getElementsByClassName("apphub_AppName")[0].textContent, appid, "#esi-store-wishlist-note");
+            that.wishlistNotes.showModalDialog(document.getElementsByClassName("apphub_AppName")[0].textContent, appid, "#esi-store-wishlist-note");
         });
     }
 


### PR DESCRIPTION
Notably, this is only the first half of solving the issue. Uncaught errors in the background context aren't handled correctly.

Upgrading the background context error handling to return valid and useful errors to display in the ProgressBar is the other half of the solution.