### PR TITLE
Fix market stats

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -2879,26 +2879,28 @@ let MarketPageClass = (function(){
             );
         }
 
+        const pageSize = 100;
         let pages = -1;
-        let p=0;
-        let pageSize = 100;
+        let currentPage = 0;
+        let currentCount = 0;
+        let totalCount;
 
         let progressNode = document.querySelector("#esi_market_stats_progress");
 
         do {
-            let data = await RequestData.getJson("https://steamcommunity.com/market/myhistory?start="+p+"&count="+pageSize);
+            let data = await RequestData.getJson("https://steamcommunity.com/market/myhistory?start="+ currentCount++ +"&count=" + pageSize);
             if (pages < 0) {
-                let totalCount = data.total_count;
-                pageSize = data.pagesize; // update page size in case we can't do as much as we want to
+                totalCount = data.total_count;
                 pages = Math.ceil(totalCount / pageSize);
             }
+
+            currentCount += data.pagesize;
 
             let dom = HTMLParser.htmlToDOM(data.results_html);
             updatePrices(dom);
 
-            p++;
-            progressNode.textContent = `${p}/${pages}`;
-        } while (p<pages);
+            progressNode.textContent = `${++currentPage}/${pages}`;
+        } while (currentCount < totalCount);
     }
 
     MarketPageClass.prototype.addMarketStats = async function() {

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -2888,7 +2888,7 @@ let MarketPageClass = (function(){
         let progressNode = document.querySelector("#esi_market_stats_progress");
 
         do {
-            let data = await RequestData.getJson("https://steamcommunity.com/market/myhistory?start="+ currentCount++ +"&count=" + pageSize);
+            let data = await RequestData.getJson("https://steamcommunity.com/market/myhistory/render/?start="+ currentCount++ +"&count=" + pageSize);
             if (pages < 0) {
                 totalCount = data.total_count;
                 pages = Math.ceil(totalCount / pageSize);

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -2879,7 +2879,7 @@ let MarketPageClass = (function(){
             );
         }
 
-        const pageSize = 100;
+        const pageSize = 500;
         let pages = -1;
         let currentPage = 0;
         let currentCount = 0;


### PR DESCRIPTION
The parameter `start` is not meant to be a page number.
Instead it should be the [index of the item, where you want to start the query](https://steamcommunity.com/groups/enhancedsteam/discussions/0/622954747302765282/#c622954747303181753).