### PR TITLE
Fit popular tags images in their bounding boxes

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -383,10 +383,6 @@ input[type=checkbox].es_dlc_selection:checked + label {
 	cursor: pointer;
 }
 
-.browse_tag_game_cap img {
-	margin-left: 8px;
-}
-
 .browse_tag_game_name {
 	margin-left: 8px;
 }


### PR DESCRIPTION
Resolves tfedor/AugmentedSteam#192

The margin increase slid the images to the right, outside of their box. In older versions of Firefox, the image was replaced by an ellipsis. In newer versions, a stripe of highlighting appears on the left and the right edge of the image is cut off.