### PR TITLE
Limit Early Access banner width

### DIFF
--- a/css/enhancedsteam-firefox.css
+++ b/css/enhancedsteam-firefox.css
@@ -56,3 +56,7 @@ span.platform_img.linux {
 .cardexchange_btn i {
 	background-image:url('moz-extension://__MSG_@@extension_id__/img/steamcardexchange.png');
 }
+
+.es_overlay {
+	max-width: 50%;
+}

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1240,7 +1240,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .es_overlay img {
 	position: absolute;
 	z-index: 4;
-	width: auto !important;
+	width: auto;
 	height: 60%;
 	min-height: 35px;
 	max-height: 120px;


### PR DESCRIPTION
Resolves tfedor/AugmentedSteam#186.

I'm not sure why the `!important`  directives are attached to the `.es_overlay` classes? We may want to remove them from the `develop` branch as well.