### PR TITLE
Assign empty object to notes if "user_notes" are undefined or null

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2893,7 +2893,7 @@ let UserNotes = (function(){
                     </div>
                 </div>`;
         
-        this.notes = SyncedStorage.get("user_notes");
+        this.notes = SyncedStorage.get("user_notes") || {};
     }
 
     UserNotes.prototype.showModalDialog = function(appname, appid, nodeSelector, onNoteUpdate) {


### PR DESCRIPTION
`null` or `undefined` user notes resulted in crashing the whole app page