### PR TITLE
Fix overlapping of sold amount in last 24 hours with native Steam item summary

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2343,12 +2343,6 @@ input[type=checkbox].es_dlc_selection:checked + label {
 #market_commodity_orders_header {
 	position: relative;
 }
-.market_commodity_orders_header .es_sold_amount {
-	position: absolute;
-	top: 36px;
-	right: 0;
-	left: 0;
-}
 .market_section_title .es_sold_amount {
 	font-size: 16px !important;
 }

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -2768,7 +2768,7 @@ let MarketListingPageClass = (function(){
                 ${Localization.str.sold_last_24.replace(`__sold__`, `<span class="market_commodity_orders_header_promote">${data.volume || 0}</span>`)}
             </div>`;
 
-        HTML.beforeEnd(".market_commodity_orders_header, .jqplot-title, .market_section_title", soldHtml);
+        HTML.beforeBegin(".market_commodity_buy_button", soldHtml);
 
         /* TODO where is this observer applied?
         let observer = new MutationObserver(function(){


### PR DESCRIPTION
Before:
![kmATZef](https://user-images.githubusercontent.com/14999077/56746970-7a2f3d80-677d-11e9-9c00-ad640aad7dee.png)

After:
![soldAmountOverlap](https://user-images.githubusercontent.com/14999077/56747018-8c10e080-677d-11e9-98af-ccb8cf2b4fa0.png)
