### PR TITLE
Filter elements

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1994,27 +1994,25 @@ input[type=checkbox].es_dlc_selection:checked + label {
  * Search result filter
  * add_hide_buttons_to_search()
  *************************************/
-.es_input_number {
-	background-color: rgba( 103, 193, 245, 0.2 );
+.es_input {
+	background-color: rgba( 0, 0, 0, 0.2 );
 	color: #fff;
-	border: 1px solid #000;
 	border-radius: 3px;
-	box-shadow: 1px 1px 0px rgba( 103, 193, 245, 0.15 );
-	width: calc(100% - 50px);
-	padding: 5px;
-}
-.es_input_text {
-	background-color: #2a3f5a;
-	color: #fff;
-	border: 1px solid #000;
-	border-radius: 3px;
-	box-shadow: 1px 1px 0px #45556c;
+	border: 1px solid rgba( 0, 0, 0, 0.3);
+	box-shadow: 1px 1px 0px rgba( 255, 255, 255, 0.2);
 	width: 200px;
 	padding: 5px;
 	margin: 5px;
 }
-.es_input_text.blur {
-	color:#62696e;
+
+.es_input:placeholder-shown, .es_input.blur {
+	font-style: italic;
+    color: #7092a5;
+    text-shadow: -1px -1px 0px rgba( 0, 0, 0, 0.4);
+}
+
+#es_notpriceabove_val {
+	width: calc(100% - 50px);
 }
 
 #es_notpriceabove_val_currency {

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -207,20 +207,20 @@ let ExtensionLayer = (function() {
 })();
 
 class Messenger {
-    static sendMessage(msgID, info) {
+    static postMessage(msgID, info) {
         window.postMessage({
             type: "es_" + msgID,
             information: info
-        }, '*');
+        }, window.location.origin);
     }
 
-    static addMessageListener(msgID, fn, autoRemove) {
+    static addMessageListener(msgID, fn, once) {
         let callback = function(e) {
             if (e.source !== window) { return; }
-            if (!e.data.type) { return; }
+            if (!e.data || !e.data.type) { return; }
             if (e.data.type === "es_" + msgID) {
                 fn(e.data.information);
-                if (autoRemove) {
+                if (once) {
                     window.removeEventListener("message", callback);
                 }
             }
@@ -232,7 +232,7 @@ class Messenger {
 // Inject the Messenger class into the DOM, providing the same interface for the page context side
 (function() {
     let script = document.createElement("script");
-    script.textContent = Messenger;
+    script.textContent = Messenger.toString();
     document.documentElement.appendChild(script);
 })();
 
@@ -666,7 +666,7 @@ let Currency = (function() {
     function getCurrencyFromWallet() {
         return new Promise((resolve, reject) => {
             ExtensionLayer.runInPageContext(() =>
-                Messenger.sendMessage("walletCurrency", typeof g_rgWalletInfo !== 'undefined' && g_rgWalletInfo ? g_rgWalletInfo.wallet_currency : null)
+                Messenger.postMessage("walletCurrency", typeof g_rgWalletInfo !== 'undefined' && g_rgWalletInfo ? g_rgWalletInfo.wallet_currency : null)
             );
 
             Messenger.addMessageListener("walletCurrency", walletCurrency => {
@@ -1670,7 +1670,7 @@ let Highlights = (function(){
         }, true);
 
         ExtensionLayer.runInPageContext(() => {
-            GDynamicStore.OnReady(() => Messenger.sendMessage("dynamicStoreReady"));
+            GDynamicStore.OnReady(() => Messenger.postMessage("dynamicStoreReady"));
         });
     };
 

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -561,9 +561,13 @@ let CurrencyRegistry = (function() {
         }
         placeholder() {
             if (this.format.decimalPlaces == 0 || this.format.hidePlacesWhenZero) {
-                return "0";
+                return '0';
             }
-            return (0).toFixed(this.format.decimalPlaces);
+            let placeholder = '0' + this.format.decimalSeparator;
+            for (let i = 0; i < this.format.decimalPlaces; ++i) {
+                placeholder += '0';
+            }
+            return placeholder;
         }
         regExp() {
             let regex = ["^("];

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -1463,7 +1463,7 @@ let Highlights = (function(){
                 let color = SyncedStorage.get(`highlight_${name}_color`);
                 hlCss.push(
                    `.es_highlighted_${name} { background: ${color} linear-gradient(135deg, rgba(0, 0, 0, 0.70) 10%, rgba(0, 0, 0, 0) 100%) !important; }
-                    .carousel_items .es_highlighted_${name}.price_inline { outline: solid ${color}; }`);
+                    .carousel_items .es_highlighted_${name}.price_inline, .curator_giant_capsule.es_highlighted_${name} { outline: solid ${color}; }`);
             });
 
             let style = document.createElement('style');
@@ -1636,6 +1636,7 @@ let Highlights = (function(){
             ".friendactivity_tab_row",                      // "Most played" and "Most wanted" tabs on recommendation pages
             ".friend_game_block",                           // "Friends recently bought"
             "div.recommendation",                           // Curator pages and the new DLC pages
+            ".curator_giant_capsule",
             "div.carousel_items.curator_featured > div",    // Carousel items on Curator pages
             ".store_capsule",                               // All sorts of items on almost every page
             ".home_marketing_message",                      // "Updates and offers"

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -1654,7 +1654,7 @@ let Highlights = (function(){
 
         parent = parent || document;
 
-        setTimeout(() => {
+        ExtensionLayer.addMessageListener("dynamicStoreReady", () => {
             selectors.forEach(selector => {
                 self.highlightAndTag(parent.querySelectorAll(selector+":not(.es_highlighted)"));
             });
@@ -1666,7 +1666,11 @@ let Highlights = (function(){
                 });
                 observer.observe(searchBoxContents, {childList: true});
             }
-        }, 1000);
+        }, true);
+
+        ExtensionLayer.runInPageContext(() => {
+            GDynamicStore.OnReady(() => AugmentedSteam.sendMessage("dynamicStoreReady"));
+        });
     };
 
     return self;

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -1655,7 +1655,7 @@ let Highlights = (function(){
 
         parent = parent || document;
 
-        ExtensionLayer.addMessageListener("dynamicStoreReady", () => {
+        Messenger.addMessageListener("dynamicStoreReady", () => {
             selectors.forEach(selector => {
                 self.highlightAndTag(parent.querySelectorAll(selector+":not(.es_highlighted)"));
             });
@@ -1670,7 +1670,7 @@ let Highlights = (function(){
         }, true);
 
         ExtensionLayer.runInPageContext(() => {
-            GDynamicStore.OnReady(() => AugmentedSteam.sendMessage("dynamicStoreReady"));
+            GDynamicStore.OnReady(() => Messenger.sendMessage("dynamicStoreReady"));
         });
     };
 

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1594,7 +1594,7 @@ let InventoryPageClass = (function(){
                     marketActions.querySelector("div"),
                     "<div class='es_loading' style='min-height: 66px;'><img src='https://steamcommunity-a.akamaihd.net/public/images/login/throbber.gif'><span>" + Localization.str.selling + "</div>"
                 );
-                ExtensionLayer.runInPageContext(`() => Messenger.sendMessage("sendFee", {feeInfo: CalculateFeeAmount(${sellPrice}, 0.10), sessionID: "${sessionId}", global_id: "${globalId}", contextID: "${contextId}", assetID: "${assetId}"})`);
+                ExtensionLayer.runInPageContext(`() => Messenger.postMessage("sendFee", {feeInfo: CalculateFeeAmount(${sellPrice}, 0.10), sessionID: "${sessionId}", global_id: "${globalId}", contextID: "${contextId}", assetID: "${assetId}"})`);
             });
         }
     }
@@ -1729,7 +1729,7 @@ let InventoryPageClass = (function(){
                     market_expired = g_ActiveInventory.selectedItem.description.descriptions.reduce((acc, el) => (acc || el.value === "This item can no longer be bought or sold on the Community Market."), false);
                 }
 
-                Messenger.sendMessage("sendMessage", [
+                Messenger.postMessage("sendMessage", [
                     iActiveSelectView,
                     g_ActiveInventory.selectedItem.description.marketable,
                     g_ActiveInventory.appid,

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2481,7 +2481,7 @@ let SearchPageClass = (function(){
                 SyncedStorage.set("priceabove_value", notpriceabove_val.value.replace(',', '.'));
                 filtersChanged();
             } else {
-                notpriceabove_val.setCustomValidity(Localization.str.price_above_tooltip);
+                notpriceabove_val.setCustomValidity(Localization.str.price_above_wrong_format.replace("__pattern__", pricePlaceholder));
             }
 
             notpriceabove_val.reportValidity();

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2338,7 +2338,7 @@ let SearchPageClass = (function(){
         HTML.afterBegin("#advsearchform .rightcol",
             `<div class='block' id='es_hide_menu'>
                 <div class='block_header'><div>${Localization.str.hide}</div></div>
-                <div class='block_content block_content_inner' style='height: 150px;' id='es_hide_options'>
+                <div class='block_content block_content_inner' id='es_hide_options'>
                     <div class='tab_filter_control' id='es_owned_games'>
                         <div class='tab_filter_control_checkbox'></div>
                         <span class='tab_filter_control_label'>${Localization.str.options.owned}</span>
@@ -2375,20 +2375,8 @@ let SearchPageClass = (function(){
                         </div>
                     </div>
                 </div>
-                <a class="see_all_expander" href="#" id="es_hide_expander"></a>
             </div>
         `);
-
-        let expander = document.querySelector("#es_hide_expander");
-        expander.addEventListener("click", function(e) {
-            e.preventDefault();
-            ExtensionLayer.runInPageContext(() =>
-                ExpandOptions(document.querySelector("#es_hide_expander"), 'es_hide_options')
-            );
-        });
-
-        let all = document.querySelectorAll(".see_all_expander");
-        expander.textContent = all[all.length-1].textContent;
 
         if (SyncedStorage.get("hide_owned")) {
             document.querySelector("#es_owned_games").classList.add("checked");
@@ -2413,19 +2401,16 @@ let SearchPageClass = (function(){
         if (SyncedStorage.get("hide_mixed")) {
             document.querySelector("#es_notmixed").classList.add("checked");
             document.querySelector("#es_hide_options").style.height="auto";
-            document.querySelector("#es_hide_expander").style.display="none";
         }
 
         if (SyncedStorage.get("hide_negative")) {
             document.querySelector("#es_notnegative").classList.add("checked");
             document.querySelector("#es_hide_options").style.height = "auto";
-            document.querySelector("#es_hide_expander").style.display = "none";
         }
 
         if (SyncedStorage.get("hide_priceabove")) {
             document.querySelector("#es_notpriceabove").classList.add("checked");
             document.querySelector("#es_hide_options").style.height = "auto";
-            document.querySelector("#es_hide_expander").style.display = "none";
         }
 
         let html = "<span id='es_notpriceabove_val_currency'>" + currency.format.symbol + "</span>";

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2397,10 +2397,10 @@ let SearchPageClass = (function(){
             }
             let observer = new MutationObserver(modifyLinks);
             observer.observe(hiddenInput, {attributes: true, attributeFilter: ["value"]});
-            ExtensionLayer.addMessageListener("ajaxCompleted", modifyLinks, false);
+            Messenger.addMessageListener("ajaxCompleted", modifyLinks, false);
         }
 
-        ExtensionLayer.addMessageListener("filtersChanged", filtersChanged, false);
+        Messenger.addMessageListener("filtersChanged", filtersChanged, false);
 
         // Thrown together from sources of searchpage.js
         ExtensionLayer.runInPageContext(`() => {
@@ -2408,7 +2408,7 @@ let SearchPageClass = (function(){
             GDynamicStore.OnReady(() => {
 
                 // Callback that will fire when the user browses through pages
-                ${!SyncedStorage.get("contscroll") ? `Ajax.Responders.register({ onComplete: () => AugmentedSteam.sendMessage("ajaxCompleted") });` : ""}
+                ${!SyncedStorage.get("contscroll") ? `Ajax.Responders.register({ onComplete: () => Messenger.sendMessage("ajaxCompleted") });` : ""}
                 
                 // For each AS hide filter
                 $J(".tab_filter_control[id^='es_']").each(function() {
@@ -2509,7 +2509,7 @@ let SearchPageClass = (function(){
                                 $J("#termsnone").hide();
                             });
                         })();
-                        AugmentedSteam.sendMessage("filtersChanged");
+                        Messenger.sendMessage("filtersChanged");
                     });
                 });
     

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -777,7 +777,7 @@ class AppPageClass extends StorePageClass {
     }
 
     addUserNote() {
-        if (!User.isSignedIn) { return; }
+        if (!User.isSignedIn || !SyncedStorage.get("showusernotes")) { return; }
 
         let noteText = "";
         let cssClass = "esi-note--hidden";
@@ -2646,7 +2646,7 @@ let WishlistPageClass = (function(){
                         if (node.parentNode !== container) { // Valve detaches wishlist entries that aren't visible
                             continue;
                         }
-                        if (myWishlist && SyncedStorage.get("showwlnotes")) {
+                        if (myWishlist && SyncedStorage.get("showusernotes")) {
                             instance.addUserNote(node);
                         } else {
                             instance.highlightApps(node); // not sure of the value of highlighting wishlisted apps on your wishlist

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2463,34 +2463,29 @@ let SearchPageClass = (function(){
         let priceFilterCheckbox = document.querySelector("#es_notpriceabove");
         priceFilterCheckbox.title = Localization.str.price_above_tooltip;
 
-        let elem = document.getElementById("es_notpriceabove_val");
-        if (elem !== undefined && elem !== null) {
-            elem.title = Localization.str.price_above_tooltip;
-            elem.addEventListener("click", function(e) {
-                e.stopPropagation()
-            });
-            elem.addEventListener("keydown", function(e){
-                if(e.key === "Enter") {
-                    // This would normally trigger a call to AjaxSearchResults() and reload the page, invalidating all AS filters
-                    e.preventDefault();
-                }
-            });
-            elem.addEventListener("input", function(e){
-                let toggleValue = (elem.value !== "");
-                priceFilterCheckbox.classList.toggle("checked", toggleValue);
-                SyncedStorage.set("hide_priceabove", toggleValue);
+        notpriceabove_val.title = Localization.str.price_above_tooltip;
+        notpriceabove_val.addEventListener("click", e => e.stopPropagation());
+        notpriceabove_val.addEventListener("keydown", e => {
+            if(e.key === "Enter") {
+                // This would normally trigger a call to AjaxSearchResults() and reload the page, invalidating all AS filters
+                e.preventDefault();
+            }
+        });
+        notpriceabove_val.addEventListener("input", () => {
+            let toggleValue = (notpriceabove_val.value !== "");
+            priceFilterCheckbox.classList.toggle("checked", toggleValue);
+            SyncedStorage.set("hide_priceabove", toggleValue);
 
-                if (inputPattern.test(elem.value)) {
-                    elem.setCustomValidity('');
-                    SyncedStorage.set("priceabove_value", elem.value.replace(',', '.'));
-                    filtersChanged();
-                } else {
-                    elem.setCustomValidity(Localization.str.price_above_tooltip);
-                }
+            if (inputPattern.test(notpriceabove_val.value)) {
+                notpriceabove_val.setCustomValidity('');
+                SyncedStorage.set("priceabove_value", notpriceabove_val.value.replace(',', '.'));
+                filtersChanged();
+            } else {
+                notpriceabove_val.setCustomValidity(Localization.str.price_above_tooltip);
+            }
 
-                elem.reportValidity();
-            });
-        }
+            notpriceabove_val.reportValidity();
+        });
 
         filtersChanged();
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -798,18 +798,18 @@ class AppPageClass extends StorePageClass {
 
         HTML.afterEnd(".queue_control_button.queue_btn_ignore",
             ` <div class="queue_control_button js-user-note-button">
-                <div class="btnv6_blue_hoverfade  btn_medium queue_btn_inactive" style="${inactiveStyle}">
+                <div id="es_add_note" class="btnv6_blue_hoverfade btn_medium queue_btn_inactive" style="${inactiveStyle}">
                     <span>${Localization.str.user_note.add}</span>
                 </div>
-                <div class="btnv6_blue_hoverfade  btn_medium queue_btn_active" style="${activeStyle}">
+                <div id="es_update_note" class="btnv6_blue_hoverfade btn_medium queue_btn_inactive" style="${activeStyle}">
                     <span>${Localization.str.user_note.update}</span>
                 </div>
             </div>`);
 
         function toggleState(node, active) {
             let button = document.querySelector(".js-user-note-button");
-            button.querySelector(".queue_btn_inactive").style.display = active ? "none" : null;
-            button.querySelector(".queue_btn_active").style.display = active ? null : "none";
+            button.querySelector("#es_add_note").style.display = active ? "none" : null;
+            button.querySelector("#es_update_note").style.display = active ? null : "none";
 
             node.classList.toggle("esi-note--hidden", !active);
         }

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2730,8 +2730,8 @@ let WishlistPageClass = (function(){
         ExtensionLayer.runInPageContext(`function(){
             var prompt = ShowConfirmDialog("${Localization.str.empty_wishlist}", \`${Localization.str.empty_wishlist_confirm}\`);
             prompt.done(function(result) {
-                if (result == 'OK') {
-                    window.postMessage({ type: 'es_empty_wishlist', information: [ true ] }, '*');
+                if (result == "OK") {
+                    Messenger.sendMessage("emptyWishlist");
                     ShowBlockingWaitDialog("${Localization.str.empty_wishlist}", \`${Localization.str.empty_wishlist_loading}\`);
                 }
             });
@@ -2752,23 +2752,21 @@ let WishlistPageClass = (function(){
             });
         }
 
-        window.addEventListener("message", function(event) {
-            if (event.source === window && event.data.type && event.data.type === "es_empty_wishlist") {
-                let wishlistData = HTMLParser.getVariableFromDom("g_rgWishlistData", "array");
-                if (!wishlistData) { return; }
+        Messenger.addMessageListener("emptyWishlist", () => {
+            let wishlistData = HTMLParser.getVariableFromDom("g_rgWishlistData", "array");
+            if (!wishlistData) { return; }
 
-                let promises = [];
-                for (let i=0; i<wishlistData.length; i++) {
-                    let appid = wishlistData[i].appid;
-                    promises.push(removeApp(appid));
-                }
-
-                Promise.all(promises).finally(() => {
-                    DynamicStore.clear();
-                    location.reload();
-                });
+            let promises = [];
+            for (let i=0; i<wishlistData.length; i++) {
+                let appid = wishlistData[i].appid;
+                promises.push(removeApp(appid));
             }
-        }, false);
+
+            Promise.all(promises).finally(() => {
+                DynamicStore.clear();
+                location.reload();
+            });
+        }, true)
     }
 
     function addWishlistPrice(node) {
@@ -2852,22 +2850,12 @@ let WishlistPageClass = (function(){
         ExtensionLayer.runInPageContext(() =>
             $J(document).ajaxSuccess(function( event, xhr, settings ) {
                 if (settings.url.endsWith("/remove/")) {
-                    window.postMessage({
-                        type: "es_remove_wl_entry",
-                        removed_wl_entry: settings.data.match(/(?!appid=)\d+/)[0]
-                    }, "*");
+                    Messenger.sendMessage("removeWlEntry", settings.data.match(/(?!appid=)\d+/)[0]);
                 }
             })
         );
 
-        window.addEventListener("message", function(e) {
-            if (e.source !== window) { return; }
-            if (!e.data.type) { return; }
-
-            if (e.data.type === "es_remove_wl_entry") {
-                userNotes.deleteNote(e.data.removed_wl_entry);
-            }
-        });
+        Messenger.addMessageListener("removeWlEntry", removedEntry => userNotes.deleteNote(removedEntry), false);
     };
 
     return WishlistPageClass;
@@ -2898,8 +2886,9 @@ let UserNotes = (function(){
 
     UserNotes.prototype.showModalDialog = function(appname, appid, nodeSelector, onNoteUpdate) {
 
+        // Partly copied from shared_global.js
         ExtensionLayer.runInPageContext(`function() {
-            // Partly copied from shared_global.js
+            debugger;
             let deferred = new jQuery.Deferred();
             let fnOK = () => deferred.resolve();
 
@@ -2909,26 +2898,9 @@ let UserNotes = (function(){
                 [], fnOK);
             deferred.always(() => Modal.Dismiss());
 
-            Modal.OnDismiss(() => {
-                window.postMessage({
-                    type: "es_modal_dismissed"
-                }, "*");
-            });
             Modal.m_fnBackgroundClick = () => {
-                function messageListener(e) {
-                    if (e.source !== window) { return; }
-                    if (!e.data.type) { return; }
-
-                    if (e.data.type === "es_note_saved") {
-                        Modal.Dismiss();
-                        window.removeEventListener("message", messageListener);
-                    }
-                }
-                window.addEventListener("message", messageListener);
-
-                window.postMessage({
-                    type: "es_background_click"
-                }, "*");
+                Messenger.addMessageListener("noteSaved", () => Modal.Dismiss(), true);
+                Messenger.sendMessage("backgroundClick");
             }
 
             Modal.Show();
@@ -2948,33 +2920,12 @@ let UserNotes = (function(){
             });
         }`);
 
-        window.addEventListener("message", messageListener);
         document.addEventListener("click", clickListener);
 
-        function messageListener(e) {
-            if (e.source !== window) { return; }
-            if (!e.data.type) { return; }
-
-            if (e.data.type === "es_modal_dismissed") {
-                document.removeEventListener("click", clickListener);
-                window.removeEventListener("message", messageListener);
-            } else if (e.data.type === "es_background_click") {
-                onNoteUpdate.apply(null, saveNote());
-                window.postMessage({
-                    type: "es_note_saved"
-                }, "*");
-            }
-        }
-
-        function backgroundClickListener(e) {
-            if (e.source !== window) { return; }
-            if (!e.data.type) { return; }
-
-            if (e.data.type === "es_modal_dismissed") {
-                document.removeEventListener("click", clickListener);
-                window.removeEventListener("message", messageListener);
-            }
-        }
+        Messenger.addMessageListener("backgroundClick", () => {
+            onNoteUpdate.apply(null, saveNote());
+            Messenger.sendMessage("noteSaved");
+        }, true);
 
         function clickListener(e) {
             if (e.target.closest(".es_note_modal_submit")) {
@@ -2983,7 +2934,10 @@ let UserNotes = (function(){
                 ExtensionLayer.runInPageContext(() => CModal.DismissActiveModal());
             } else if (e.target.closest(".es_note_modal_close")) {
                 ExtensionLayer.runInPageContext(() => CModal.DismissActiveModal());
+            } else {
+                return;
             }
+            document.removeEventListener("click", clickListener);
         }
 
         let that = this;

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2335,115 +2335,232 @@ let SearchPageClass = (function(){
         let pricePlaceholder = currency.placeholder();
 
         await User;
+
         HTML.afterBegin("#advsearchform .rightcol",
-            `<div class='block' id='es_hide_menu'>
-                <div class='block_header'><div>${Localization.str.hide}</div></div>
-                <div class='block_content block_content_inner' id='es_hide_options'>
-                    ${User.isSignedIn ? `<div class='tab_filter_control' id='es_owned_games'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.options.owned}</span>
+            `<div class="block" id="es_hide_menu">
+                <div class="block_header"><div>${Localization.str.hide}</div></div>
+                <div class="block_content block_content_inner" id="es_hide_options">
+                    ${User.isSignedIn ? `<div class="tab_filter_control" id="es_owned_games" data-param="es_hide" data-value="owned">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.options.owned}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_wishlist_games'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.options.wishlist}</span>
+                    <div class="tab_filter_control" id="es_wishlist_games" data-param="es_hide" data-value="wishlisted">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.options.wishlist}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_notinterested'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.notinterested}</span>
+                    <div class="tab_filter_control" id="es_notinterested" data-param="es_hide" data-value="ignored">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.notinterested}</span>
                     </div>` : ""}
-                    <div class='tab_filter_control' id='es_cart_games'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.options.cart}</span>
+                    <div class="tab_filter_control" id="es_cart_games" data-param="es_hide" data-value="cart">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.options.cart}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_notdiscounted'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.notdiscounted}</span>
+                    <div class="tab_filter_control" id="es_notdiscounted" data-param="es_hide" data-value="not-discounted">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.notdiscounted}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_notmixed'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.mixed_item}</span>
+                    <div class="tab_filter_control" id="es_notmixed" data-param="es_hide" data-value="mixed">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.mixed_item}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_notnegative'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.negative_item}</span>
+                    <div class="tab_filter_control" id="es_notnegative" data-param="es_hide" data-value="negative">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.negative_item}</span>
                     </div>
-                    <div class='tab_filter_control' id='es_notpriceabove'>
-                        <div class='tab_filter_control_checkbox'></div>
-                        <span class='tab_filter_control_label'>${Localization.str.price_above}</span>
+                    <div class="tab_filter_control" id="es_notpriceabove" data-param="es_hide" data-value="price-above">
+                        <div class="tab_filter_control_checkbox"></div>
+                        <span class="tab_filter_control_label">${Localization.str.price_above}</span>
                         <div>
-                            <input type="text" id='es_notpriceabove_val' class='es_input' pattern='${inputPattern.source}' placeholder=${pricePlaceholder}>
+                            <input type="text" id="es_notpriceabove_val" class="es_input" pattern="${inputPattern.source}" placeholder=${pricePlaceholder}>
                         </div>
+                    </div>
+                    <div>
+                        <input type="hidden" id="es_hide" name="es_hide" value>
                     </div>
                 </div>
             </div>
         `);
 
-        let html = "<span id='es_notpriceabove_val_currency'>" + currency.format.symbol + "</span>";
-        let notpriceabove_val = document.querySelector("#es_notpriceabove_val");
-
-        if (currency.format.postfix) {
-            HTML.afterEnd(notpriceabove_val, html);
-        } else {
-            HTML.beforeBegin(notpriceabove_val, html);
+        if (!SyncedStorage.get("contscroll")) {
+            let hiddenInput = document.getElementById("es_hide");
+            function modifyLinks() {
+                for (let linkElement of document.querySelectorAll(".search_pagination_right a")) {
+                    let params = new URLSearchParams(linkElement.href.substring(linkElement.href.indexOf('?')));
+                    if (hiddenInput.value) {
+                        params.set("es_hide", hiddenInput.value);
+                    } else {
+                        params.delete("es_hide");
+                    }
+                    linkElement.href = linkElement.href.substring(0, linkElement.href.indexOf('?') + 1) + params.toString();
+                }
+            }
+            let observer = new MutationObserver(modifyLinks);
+            observer.observe(hiddenInput, {attributes: true, attributeFilter: ["value"]});
+            ExtensionLayer.addMessageListener("ajaxCompleted", modifyLinks, false);
         }
 
-        let ids = [
-            "es_cart_games",
-            "es_notdiscounted",
-            "es_notmixed",
-            "es_notnegative"
-        ];
+        ExtensionLayer.addMessageListener("filtersChanged", filtersChanged, false);
 
-        if (User.isSignedIn) {
-            ids.push("es_owned_games");
-            ids.push("es_wishlist_games");
-            ids.push("es_notinterested");
-        }
+        // Thrown together from sources of searchpage.js
+        ExtensionLayer.runInPageContext(`() => {
 
-        for (let id of ids) {
-            let option = document.getElementById(id);
-            option.addEventListener("click", () => {
-                let state = !option.classList.contains("checked");
-                option.classList.toggle("checked", state);
-                filtersChanged();
-            });
-        }
+            GDynamicStore.OnReady(() => {
 
-        {
-            let option = document.getElementById("es_notpriceabove");
-            option.addEventListener("click", () => {
-                let state = !option.classList.contains("checked");
-                option.classList.toggle("checked", state);
-                if (option.querySelector("#es_notpriceabove_val").value) {
-                    filtersChanged();
+                // Callback that will fire when the user browses through pages
+                ${!SyncedStorage.get("contscroll") ? `Ajax.Responders.register({ onComplete: () => AugmentedSteam.sendMessage("ajaxCompleted") });` : ""}
+                
+                // For each AS hide filter
+                $J(".tab_filter_control[id^='es_']").each(function() {
+                    let $Control = $J(this);
+                    let strParam = $Control.data("param");
+                    let value = $Control.data("value");
+        
+                    $Control.click(() => {
+                        let strValues = decodeURIComponent($J('#' + strParam).val());
+                        value = String(value); // Javascript: Dynamic types except sometimes not.
+                        if (!$Control.hasClass("checked")) {
+                            let rgValues;
+                            if(!strValues) {
+                                rgValues = [value];
+                            } else {
+                                rgValues = strValues.split(',');
+                                if($J.inArray(value, rgValues) === -1) {
+                                    rgValues.push(value)
+                                }  
+                            }
+        
+                            $J('#' + strParam).val(rgValues.join(','));
+                            $Control.addClass("checked");
+                        } else {
+                            let rgValues = strValues.split(',');
+                            if(rgValues.indexOf(value) !== -1) {
+                                rgValues.splice( rgValues.indexOf(value), 1 );
+                            }
+    
+                            $J('#' + strParam).val(rgValues.join(','));
+                            $Control.removeClass("checked");
+                        }
+    
+                        let rgParameters = GatherSearchParameters();
+    
+                        // remove snr for history purposes
+                        delete rgParameters["snr"];
+                        if (rgParameters["sort_by"] === "_ASC") {
+                            delete rgParameters["sort_by"];
+                        }
+                        if (rgParameters["page"] === 1 || rgParameters["page"] === '1')
+                            delete rgParameters["page"];
+    
+                        // don't want this on the url either
+                        delete rgParameters["hide_filtered_results_warning"];
+    
+                        if (g_bUseHistoryAPI) {
+                            history.pushState({ params: rgParameters}, '', '?' + Object.toQueryString( rgParameters ) );
+                        } else {
+                            window.location = '#' + Object.toQueryString( rgParameters );
+                        }
+    
+                        (function UpdateCustomTags() {
+                            $J(".tag_dynamic").remove();
+                            $J("#termsnone").show();
+                            let rgActiveTags = $J(".tab_filter_control.checked");
+    
+                            // Search term
+                            let strTerm = $J("#realterm").val();
+                            if( strTerm )
+                            {
+                                AddSearchTag( "term", strTerm, '"'+strTerm+'"', function(tag) { $J("#realterm").val(''); $J("#term").val(''); AjaxSearchResults(); return false; } );
+                                $J("#termsnone").hide();
+                            }
+    
+                            // Publisher
+                            let strPublisher = $J("#publisher").val();
+                            if( strPublisher )
+                            {
+                                AddSearchTag( "publisher", strPublisher, "Publisher" + ": "+strPublisher, function(tag) { $J("#publisher").val(''); AjaxSearchResults(); return false; } );
+                                $J("#termsnone").hide();
+                            }
+    
+                            // Developer
+                            let strDeveloper = $J("#developer").val();
+                            if( strDeveloper )
+                            {
+                                AddSearchTag("publisher", strDeveloper, "Developer" + ": " + strDeveloper, function(tag) { $J("#developer").val(''); AjaxSearchResults(); return false; } );
+                                $J("#termsnone").hide();
+                            }
+    
+                            rgActiveTags.each(function() {
+                                let Tag = this;
+                                let $Tag = $J(this);
+                                let label;
+    
+                                if ($Tag.is("[id*='es_']")) {
+                                    label = "${Localization.str.hide_filter}".replace("__filter__", $J(".tab_filter_control_label", Tag).text());
+                                } else {
+                                    label = $J(".tab_filter_control_label", Tag).text();
+                                }
+                                AddSearchTag($Tag.data("param"), $Tag.data("value"), label, function(tag) { return function() { tag.click(); return false; } }(Tag) );
+                                if (!$Tag.is(":visible"))
+                                {
+                                    $Tag.parent().prepend($Tag.show());
+                                    $Tag.trigger( "tablefilter_update" );
+                                }
+                                $J("#termsnone").hide();
+                            });
+                        })();
+                        AugmentedSteam.sendMessage("filtersChanged");
+                    });
+                });
+    
+                for (let [key, value] of new URLSearchParams(window.location.search)) {
+                    if (key === "es_hide") {
+                        for (let filterValue of value.split(',')) {
+                            let filter = $J(".tab_filter_control[data-value='" + filterValue + "']");
+                            if (filter) {
+                                filter.click();
+                            } else {
+                                console.warn("Invalid filter value %s", filterValue);
+                            }
+                        }
+                    }
                 }
             });
+        }`);
+
+        let html = "<span id='es_notpriceabove_val_currency'>" + currency.format.symbol + "</span>";
+        let priceAboveVal = document.querySelector("#es_notpriceabove_val");
+
+        if (currency.format.postfix) {
+            HTML.afterEnd(priceAboveVal, html);
+        } else {
+            HTML.beforeBegin(priceAboveVal, html);
         }
 
         let priceFilterCheckbox = document.querySelector("#es_notpriceabove");
         priceFilterCheckbox.title = Localization.str.price_above_tooltip;
 
-        notpriceabove_val.title = Localization.str.price_above_tooltip;
-        notpriceabove_val.addEventListener("click", e => e.stopPropagation());
-        notpriceabove_val.addEventListener("keydown", e => {
+        priceAboveVal.title = Localization.str.price_above_tooltip;
+        priceAboveVal.addEventListener("click", e => e.stopPropagation());
+        priceAboveVal.addEventListener("keydown", e => {
             if(e.key === "Enter") {
-                // This would normally trigger a call to AjaxSearchResults() and reload the page, invalidating all AS filters
+                // This would normally trigger a call to AjaxSearchResults() which is not required here
                 e.preventDefault();
             }
         });
-        notpriceabove_val.addEventListener("input", () => {
-            let newValue = notpriceabove_val.value;
+        priceAboveVal.addEventListener("input", () => {
+            let newValue = priceAboveVal.value;
             let toggleValue = (newValue !== "");
             priceFilterCheckbox.classList.toggle("checked", toggleValue);
 
             if (inputPattern.test(newValue)) {
                 filtersChanged();
-                notpriceabove_val.setCustomValidity('');
+                priceAboveVal.setCustomValidity('');
             } else {
-                notpriceabove_val.setCustomValidity(Localization.str.price_above_wrong_format.replace("__pattern__", pricePlaceholder));
+                priceAboveVal.setCustomValidity(Localization.str.price_above_wrong_format.replace("__pattern__", pricePlaceholder));
             }
 
-            notpriceabove_val.reportValidity();
+            priceAboveVal.reportValidity();
         });
     };
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2731,7 +2731,7 @@ let WishlistPageClass = (function(){
             var prompt = ShowConfirmDialog("${Localization.str.empty_wishlist}", \`${Localization.str.empty_wishlist_confirm}\`);
             prompt.done(function(result) {
                 if (result == "OK") {
-                    Messenger.sendMessage("emptyWishlist");
+                    Messenger.postMessage("emptyWishlist");
                     ShowBlockingWaitDialog("${Localization.str.empty_wishlist}", \`${Localization.str.empty_wishlist_loading}\`);
                 }
             });
@@ -2756,13 +2756,7 @@ let WishlistPageClass = (function(){
             let wishlistData = HTMLParser.getVariableFromDom("g_rgWishlistData", "array");
             if (!wishlistData) { return; }
 
-            let promises = [];
-            for (let i=0; i<wishlistData.length; i++) {
-                let appid = wishlistData[i].appid;
-                promises.push(removeApp(appid));
-            }
-
-            Promise.all(promises).finally(() => {
+            Promise.all(wishlistData.map(app => removeApp(app.appid))).finally(() => {
                 DynamicStore.clear();
                 location.reload();
             });
@@ -2850,7 +2844,7 @@ let WishlistPageClass = (function(){
         ExtensionLayer.runInPageContext(() =>
             $J(document).ajaxSuccess(function( event, xhr, settings ) {
                 if (settings.url.endsWith("/remove/")) {
-                    Messenger.sendMessage("removeWlEntry", settings.data.match(/(?!appid=)\d+/)[0]);
+                    Messenger.postMessage("removeWlEntry", settings.data.match(/(?!appid=)\d+/)[0]);
                 }
             })
         );
@@ -2899,7 +2893,7 @@ let UserNotes = (function(){
 
             Modal.m_fnBackgroundClick = () => {
                 Messenger.addMessageListener("noteSaved", () => Modal.Dismiss(), true);
-                Messenger.sendMessage("backgroundClick");
+                Messenger.postMessage("backgroundClick");
             }
 
             Modal.Show();
@@ -2923,7 +2917,7 @@ let UserNotes = (function(){
 
         Messenger.addMessageListener("backgroundClick", () => {
             onNoteUpdate.apply(null, saveNote());
-            Messenger.sendMessage("noteSaved");
+            Messenger.postMessage("noteSaved");
         }, true);
 
         function clickListener(e) {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2888,7 +2888,6 @@ let UserNotes = (function(){
 
         // Partly copied from shared_global.js
         ExtensionLayer.runInPageContext(`function() {
-            debugger;
             let deferred = new jQuery.Deferred();
             let fnOK = () => deferred.resolve();
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2220,7 +2220,7 @@ let SearchPageClass = (function(){
                  </div>
                  <div class='block_content block_content_inner'>
                     <div style='max-height: 150px; overflow: hidden;' id='es_tagfilter_exclude_container'></div>
-                    <input type="text" id="es_tagfilter_exclude_suggest" class="blur es_input_text">
+                    <input type="text" id="es_tagfilter_exclude_suggest" class="es_input">
                 </div>
             </div>`);
 
@@ -2272,7 +2272,7 @@ let SearchPageClass = (function(){
         }
 
         ExtensionLayer.runInPageContext(() =>
-            $J('#es_tagfilter_exclude_container').tableFilter({ maxvisible: 15, control: '#es_tagfilter_exclude_suggest', dataattribute: 'loc', 'defaultText': jQuery("#TagSuggest")[0].value })
+            $J("#es_tagfilter_exclude_container").tableFilter({ maxvisible: 15, control: "#es_tagfilter_exclude_suggest", dataattribute: "loc", defaultText: $J("#TagSuggest").attr("value")})
         );
 
         let observer = new MutationObserver(function(mutations) {
@@ -2371,7 +2371,7 @@ let SearchPageClass = (function(){
                         <div class='tab_filter_control_checkbox'></div>
                         <span class='tab_filter_control_label'>${Localization.str.price_above}</span>
                         <div>
-                            <input type="text" id='es_notpriceabove_val' class='es_input_number' pattern='${inputPattern.source}' placeholder=${pricePlaceholder}>
+                            <input type="text" id='es_notpriceabove_val' class='es_input' pattern='${inputPattern.source}' placeholder=${pricePlaceholder}>
                         </div>
                     </div>
                 </div>

--- a/js/core.js
+++ b/js/core.js
@@ -218,7 +218,7 @@ class UpdateHandler {
             }
             SyncedStorage.set("user_notes", SyncedStorage.get("wishlist_notes"));
             SyncedStorage.remove("wishlist_notes");
-        } else if (oldVersion.isSameOrBefore("0.9.6")) {
+        } else if (oldVersion.isSameOrBefore("0.9.7")) {
             SyncedStorage.remove("hide_wishlist");
             SyncedStorage.remove("hide_cart");
             SyncedStorage.remove("hide_notdiscounted");

--- a/js/core.js
+++ b/js/core.js
@@ -202,26 +202,31 @@ class UpdateHandler {
             SyncedStorage.set("hideaboutlinks", SyncedStorage.get("hideinstallsteambutton") && SyncedStorage.get("hideaboutmenu"));
             SyncedStorage.remove("hideinstallsteambutton");
             SyncedStorage.remove("hideaboutmenu");
-
+            // Update structure for custom profile links to allow multiple
+            if (SyncedStorage.get('profile_custom_name')) {
+                let custom_link = {
+                    'enabled': SyncedStorage.get('profile_custom'),
+                    'name': SyncedStorage.get('profile_custom_name'),
+                    'url': SyncedStorage.get('profile_custom_url'),
+                    'icon':  SyncedStorage.get('profile_custom_icon'),
+                };
+                SyncedStorage.set('profile_custom_link', [custom_link,]);
+                SyncedStorage.remove('profile_custom');
+                SyncedStorage.remove('profile_custom_name');
+                SyncedStorage.remove('profile_custom_url');
+                SyncedStorage.remove('profile_custom_icon');
+            }
             SyncedStorage.set("user_notes", SyncedStorage.get("wishlist_notes"));
             SyncedStorage.remove("wishlist_notes");
-        }
-
-        if (oldVersion.isSameOrBefore("0.9.5")) {
-            // Update structure for custom profile links to allow multiple
-            let custom_link = {
-                'enabled': SyncedStorage.get('profile_custom'),
-                'name': SyncedStorage.get('profile_custom_name'),
-                'url': SyncedStorage.get('profile_custom_url'),
-                'icon':  SyncedStorage.get('profile_custom_icon'),
-            };
-            SyncedStorage.set('profile_custom_link', [custom_link,]);
-            SyncedStorage.remove('profile_custom');
-            SyncedStorage.remove('profile_custom_name');
-            SyncedStorage.remove('profile_custom_url');
-            SyncedStorage.remove('profile_custom_icon');
-    }
-    
+        } else if (oldVersion.isSameOrBefore("0.9.6")) {
+            SyncedStorage.remove("hide_wishlist");
+            SyncedStorage.remove("hide_cart");
+            SyncedStorage.remove("hide_notdiscounted");
+            SyncedStorage.remove("hide_mixed");
+            SyncedStorage.remove("hide_negative");
+            SyncedStorage.remove("hide_priceabove");
+            SyncedStorage.remove("priceabove_value");
+        }    
     }
 }
 

--- a/js/core.js
+++ b/js/core.js
@@ -536,7 +536,7 @@ SyncedStorage.defaults = {
     'hideaboutlinks': false,
     'keepssachecked': false,
     'showemptywishlist': true,
-    'showwlnotes': true,
+    'showusernotes': true,
     'user_notes': {},
     'replaceaccountname': true,
     'showfakeccwarning': true,

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -129,6 +129,7 @@
     "negative_item": "Negative rating items",
     "price_above":"Items that cost more than",
     "price_above_tooltip":"Enter zero for free items or items without price tags; leave this field empty to disable this feature",
+    "price_above_wrong_format": "Wrong format, expected input in the form of __pattern__",
     "news": "News",
     "check_system": "Check Your System",
     "viewinclient": "View in Steam Client",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -399,7 +399,7 @@
         "profile_link_images_color": "Colored",
         "hide_about_links": "Hide \"Install Steam\" button / \"About\" link",
         "show_empty_wishlist": "Show \"Empty Wishlist\" button",
-        "show_wl_notes": "Show notes on wishlist",
+        "show_user_notes": "Show user notes on wishlist and app pages",
         "inventory_nav_text": "Show advanced navigation on inventory page",
         "carousel_description": "Show app descriptions on storefront carousel",
         "market_total": "Show transaction summary on Market",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -117,6 +117,7 @@
     "highlight": "Highlight",
     "save": "Save",
     "not": "Not __tag__",
+    "hide_filter": "Hide __filter__",
     "add_to_cart": "Add to Cart",
     "view": "View",
     "games_all": "All Games",

--- a/localization/zh-CN/strings.json
+++ b/localization/zh-CN/strings.json
@@ -394,7 +394,6 @@
         "showspeechsearch": "为搜索框添加语音输入功能",
         "profile_link_images_color": "彩色",
         "show_empty_wishlist": "显示“清空愿望单”按钮",
-        "show_wl_notes": "在愿望单上显示愿望单备注",
         "inventory_nav_text": "在库存页面启用高级导航功能",
         "carousel_description": "在商店首页轮盘中显示简介",
         "market_total": "显示市场交易总额",

--- a/localization/zh-TW/strings.json
+++ b/localization/zh-TW/strings.json
@@ -394,7 +394,6 @@
         "showspeechsearch": "在搜尋欄位加入語音輸入",
         "profile_link_images_color": "彩色",
         "show_empty_wishlist": "顯示「清空願望清單」按鈕",
-        "show_wl_notes": "在願望清單上顯示願望清單備註",
         "inventory_nav_text": "在物品庫頁面中顯示進階導覽功能",
         "carousel_description": "在商店頁面的跑燈中顯示應用描述",
         "market_total": "在市集頁面中顯示交易摘要",

--- a/options.html
+++ b/options.html
@@ -282,8 +282,8 @@
                 <label for="showemptywishlist" id="store_hide_empty_wishlist" data-locale-text="options.show_empty_wishlist">Show "Empty Wishlist" button</label>
             </div>
             <div>
-                <input type="checkbox" id="showwlnotes" data-setting="showwlnotes">
-                <label for="showwlnotes" id="store_show_wl_notes" data-locale-text="options.show_wl_notes">Show wishlist notes on wishlist</label>
+                <input type="checkbox" id="showusernotes" data-setting="showusernotes">
+                <label for="showusernotes" id="store_show_user_notes" data-locale-text="options.show_user_notes">Show user notes on wishlist and app pages</label>
             </div>
             <div>
                 <input type="checkbox" id="send_age_info" data-setting="send_age_info">


### PR DESCRIPTION
Depends on #231 

- Adjusts the style of the filter elements on the search page to the native Steam ones
- Fix placeholder of price input (respect the currency's decimal separator)
- Give a hint on how the input for the price is expected to look like (e.g. 0,00 for EUR)
- Remove "See all" expander (this just hid some very useful features of AS imo)
- Respect user state when displaying filters (owned, wishlisted, ignored filters are hidden when logged out)
- Fix for the "Update note" button always shown as active
- Hide user notes button on app page when user has already disabled them on their wishlist
- And finally, stop saving the states of the filters (en- or disabled) in `SyncedStorage`, instead save that in the query string like the native filters also do