### PR TITLE
Added some missing profile colour elements

### DIFF
--- a/img/profile_styles/blue/style.css
+++ b/img/profile_styles/blue/style.css
@@ -14,3 +14,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	background: #000 !important;
+}

--- a/img/profile_styles/green/style.css
+++ b/img/profile_styles/green/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #54CF72 !important;
+}

--- a/img/profile_styles/grey/style.css
+++ b/img/profile_styles/grey/style.css
@@ -10,7 +10,14 @@
 .btn_profile_action:hover > span, .btn_profile_action.focus > span {
 	background: linear-gradient( to bottom, #6e6e6e 5%, #272727 95%) !important;
 }
+.profile_customization_header {
+	color: #868686 !important;
+}
 .profile_header_badge {
 	background-color: rgba(22,22,22, 0.6) !important;
 	box-shadow: none !important;
+}
+.profile_customization.customization_edit.none_selected {
+	background: #404040 !important;
+	border: 1px dashed #868686 !important;
 }

--- a/img/profile_styles/orange/style.css
+++ b/img/profile_styles/orange/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #FF7A1A !important;
+}

--- a/img/profile_styles/pink/style.css
+++ b/img/profile_styles/pink/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #FF5CCC !important;
+}

--- a/img/profile_styles/purple/style.css
+++ b/img/profile_styles/purple/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #8F42FF !important;
+}

--- a/img/profile_styles/red/style.css
+++ b/img/profile_styles/red/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #C83939 !important;
+}

--- a/img/profile_styles/teal/style.css
+++ b/img/profile_styles/teal/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #54CFCF !important;
+}

--- a/img/profile_styles/yellow/style.css
+++ b/img/profile_styles/yellow/style.css
@@ -17,3 +17,6 @@
 	background-color: rgba(22,22,23, 0.6) !important;
 	box-shadow: none !important;
 }
+.profile_customization.customization_edit.none_selected {
+	border: 1px dashed #CCCF54 !important;
+}


### PR DESCRIPTION
All coloured profiles now have a properly-coloured border for the 'Add a Showcase' box. Grey theme was also missing its text colour on showcase names, and Blue theme's 'Add a Showcase' looked slightly odd with the default gradient still on the side.