### PR TITLE
Added group members kicker

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -3619,16 +3619,16 @@ let GroupMembersManagePage = (function(){
             (new WorkshopPageClass());
             break;
 
-        case /^\/(?:gid|groups)\/[^\/]+\/membersManage\/?$/g.test(path):
+        case /^\/groups\/[^\/]+\/membersManage\/?$/.test(path):
             (new GroupMembersManagePage());
             break;
 
-        case /^\/(?:gid|groups)\/[^\/]+\/?$/g.test(path):
+        case /^\/groups\/[^\/]+\/?$/.test(path):
             let membersCount = Number(document.querySelector(".membercount.members .count").innerText);
             if (membersCount > 1) { return; }
 
             let webLink = document.querySelector("[href*=ConfirmLeaveGroup]");
-            webLink.innerHTML = `<img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/notification_icon_trash_bright.png"> ${Localization.str.delete_group}`
+            HTML.inner(webLink, `<img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/notification_icon_trash_bright.png"> ${Localization.str.delete_group}`);
             break;
 
         case /^\/tradingcards\/boostercreator/.test(path):

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -1,4 +1,8 @@
 {
+    "kick_all_confirm": "Are you sure you want to kick all your group members, excluding you?<br>This action cannot be undone!",
+    "kick_all_loading": "Executing... Kicked __i__/__total__ group members",
+    "kick_all_members": "Kick All Group Members",
+    "delete_group": "Delete group",
     "post_history": "View post history",
     "add_nickname": "Add Nickname",
     "total_size": "Total Size",

--- a/localization/nl/strings.json
+++ b/localization/nl/strings.json
@@ -1,4 +1,8 @@
 {
+    "kick_all_confirm": "Weet u zeker dat u alle groepleden wilt kicken?<br>Deze actie kan niet ongedaan worden gemaakt!",
+    "kick_all_loading": "Uitvoeren... __i__ van de __total__ groepleden gekickt",
+    "kick_all_members": "Alle Groepleden Kicken",
+    "delete_group": "Groep verwijderen",
     "post_history": "Bekijk post geschiedenis",
     "add_nickname": "Bijnaam toevoegen",
     "total_size": "Totale grote",


### PR DESCRIPTION
Based on my userscript: https://greasyfork.org/en/scripts/26242-steam-community-group-members-kicker

This is useful for when you want to delete a steam group you made and you have too many members to kick one by one. It kicks everyone, but you. And when you're the only member of the group, the "Leave group" link turns into "Delete group" instead now. 

![image](https://user-images.githubusercontent.com/4411977/62828778-8df89580-bbee-11e9-9187-a8536a49e670.png)
![image](https://user-images.githubusercontent.com/4411977/62828779-95b83a00-bbee-11e9-9394-bbe6c8a2024f.png)
![image](https://user-images.githubusercontent.com/4411977/62828789-a5378300-bbee-11e9-94f3-a18781668ecb.png)
