### PR TITLE
Add support for community steam links that apply cards images to the link tag

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -244,7 +244,8 @@ let ProfileActivityPageClass = (function(){
             let links = node.querySelectorAll("a:not(.blotter_gamepurchase_logo)");
             for (let link of links) {
                 let appid = GameId.getAppid(link.href);
-                if (!appid || link.childElementCount !== 0) { continue; }
+                if (!appid || link.childElementCount > 1) { continue; }
+                if (link.childElementCount === 1 && link.children[0].tagName !== 'IMG') { continue; }
 
                 if (DynamicStore.isOwned(appid)) {
                     Highlights.highlightOwned(link);


### PR DESCRIPTION
Some steam groups  post links to the steam pages, but also apply a card image to the link itself.
In the code here script update only links, that don't have any children elements, so this links will not be parsed. Here I made sure, that this kind of links will be valid. Although I am not sure why validation by the nodes exists. What will break, if it's removed completely?

Example page to track in community:
https://steamcommunity.com/groups/IndieBundleTracker#announcements/detail/3326392068396183880