### PR TITLE
Add fullscreen screenshot view at app pages

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1281,6 +1281,98 @@ input[type=checkbox].es_dlc_selection:checked + label {
 }
 
 /***************************************
+ * App pages
+ * addFullscreenScreenshotView()
+ **************************************/
+.es_screenshot_fullscreen_toggle {
+	position: absolute;
+	right: 18%;
+	bottom: 0;
+}
+.es_screenshot_fullscreen_toggle i {
+	display: block;
+	background-image: url('data:image/gif;base64,R0lGODlhEAAgAIABAP///////yH5BAEAAAEALAAAAAAQACAAAAJAjH+gC+jB1HNxpmqjnHVz31iQOIoh5D0Spmom+y0kypDaOWf2hVMNjLi9asNUTFZECpO9FjIDDLqOvyYvscsVAAA7');
+	background-position: top left;
+	width: 16px;
+	height: 16px;
+	margin: 5px;
+}
+.es_screenshot_download_btn {
+	position: absolute;
+	right: 24%;
+	bottom: 0;
+}
+.es_screenshot_download_btn i {
+	display: block;
+	background-image: url(https://steamcommunity-a.akamaihd.net/public/shared/images/header/btn_header_installsteam_download.png?v=1);
+	background-position: center;
+	background-repeat: no-repeat;
+	width: 16px;
+	height: 16px;
+	margin: 5px;
+}
+.screenshot_popup_modal_content:fullscreen .es_screenshot_fullscreen_toggle i {
+	background-position: bottom left;
+}
+.screenshot_popup_modal_content:fullscreen {
+	padding: 0;
+	background: none;
+}
+.screenshot_popup_modal_content .screenshot_popup_modal_title {
+	display: none;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_img_ctn {
+	width: 100%;
+	height: 100%;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_img_ctn > img {
+	max-width: 100% !important;
+	max-height: 100% !important;
+	object-fit: scale-down;
+	width: 100%;
+	height: 100%;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_popup_modal_footer {
+	position: absolute;
+	width: 100%;
+	bottom: 0;
+	overflow: visible;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_popup_modal_footer > .btn_medium {
+	opacity: 0;
+	transition: opacity 0.25s ease-in-out;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_popup_modal_footer:hover > .btn_medium {
+	opacity: 1;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_popup_modal_footer > div:first-child {
+	display: inline-block;
+	background: rgba(103, 193, 245, 0.2);
+	border-radius: 100px;
+	padding: 0 1em;
+}
+.screenshot_popup_modal_content:fullscreen .screenshot_popup_modal_footer > .previous::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	width: 40vw;
+	height: 100vh;
+}
+@keyframes es_screenshot_popup_modal_hook {
+	from {
+		opacity: 0.99;
+	}
+	to {
+		opacity: 1;
+	}
+}
+.screenshot_popup_modal {
+	animation-duration: 0.001s;
+	animation-name: es_screenshot_popup_modal_hook;
+}
+
+/***************************************
  * Store and Community
  * add_language_warning(),
  * add_fake_country_code_warning()

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -923,13 +923,10 @@ class AppPageClass extends StorePageClass {
             }
         }
 
-        function es_initFSVButton(event) {
+        function es_initFSVButtons(event) {
             if (event.animationName !== "es_screenshot_popup_modal_hook") return;
 
             let modalFooter = document.querySelector(".screenshot_popup_modal_footer");
-            let fsvButton = document.createElement('div');
-            fsvButton.classList.add("btnv6_blue_hoverfade", "btn_medium", "es_screenshot_fullscreen_toggle");
-            fsvButton.innerHTML = "<i></i>";
             let nextButton = modalFooter.querySelector(".next");
             let nextButtonOffsetWidth = nextButton.offsetWidth;
             if (nextButton.style.display === "none") {
@@ -937,23 +934,21 @@ class AppPageClass extends StorePageClass {
                 nextButtonOffsetWidth = nextButton.offsetWidth;
                 nextButton.style.display = "none";
             }
-            fsvButton.style.right = `calc(${nextButtonOffsetWidth}px + 0.5em)`;
+            HTML.beforeEnd(modalFooter,
+                `<div class="btnv6_blue_hoverfade btn_medium es_screenshot_fullscreen_toggle" style="right: calc(${nextButtonOffsetWidth}px + 0.5em)"><i></i></div>`);
+            let fsvButton = modalFooter.querySelector(".es_screenshot_fullscreen_toggle");
             fsvButton.addEventListener("click", es_toggleFullScreen);
-            modalFooter.appendChild(fsvButton);
 
-            let downloadButton = document.createElement('a');
-            downloadButton.classList.add("btnv6_blue_hoverfade", "btn_medium", "es_screenshot_download_btn");
             let modalTitleLink = modalFooter.parentElement.querySelector(".screenshot_popup_modal_title > a");
-            downloadButton.title = modalTitleLink.textContent.trim();
-            downloadButton.innerHTML = "<i></i>";
-            downloadButton.style.right = `calc(${nextButtonOffsetWidth + fsvButton.offsetWidth}px + 1em)`;
+            HTML.beforeEnd(modalFooter,
+                `<div class="btnv6_blue_hoverfade btn_medium es_screenshot_download_btn" style="right: calc(${nextButtonOffsetWidth + fsvButton.offsetWidth}px + 1em)" title="${modalTitleLink.textContent.trim()}"><i></i></div>`);
+            let downloadButton = modalFooter.querySelector(".es_screenshot_download_btn");
             downloadButton.addEventListener("click", () => {
                 modalTitleLink.click();
             });
-            modalFooter.appendChild(downloadButton);
         }
 
-        document.addEventListener("animationstart", es_initFSVButton);
+        document.addEventListener("animationstart", es_initFSVButtons);
     }
 
     getFirstSubid() {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -914,7 +914,7 @@ class AppPageClass extends StorePageClass {
     }
 
     addFullscreenScreenshotView() {
-        function es_toggleFullScreen(event) {
+        function toggleFullScreen(event) {
             if (!document.fullscreenElement) {
                 let element = event.target.closest(".screenshot_popup_modal_content");
                 element.requestFullscreen();
@@ -923,7 +923,7 @@ class AppPageClass extends StorePageClass {
             }
         }
 
-        function es_initFSVButtons(event) {
+        function initFSVButtons(event) {
             if (event.animationName !== "es_screenshot_popup_modal_hook") return;
 
             let modalFooter = document.querySelector(".screenshot_popup_modal_footer");
@@ -937,7 +937,7 @@ class AppPageClass extends StorePageClass {
             HTML.beforeEnd(modalFooter,
                 `<div class="btnv6_blue_hoverfade btn_medium es_screenshot_fullscreen_toggle" style="right: calc(${nextButtonOffsetWidth}px + 0.5em)"><i></i></div>`);
             let fsvButton = modalFooter.querySelector(".es_screenshot_fullscreen_toggle");
-            fsvButton.addEventListener("click", es_toggleFullScreen);
+            fsvButton.addEventListener("click", toggleFullScreen);
 
             let modalTitleLink = modalFooter.parentElement.querySelector(".screenshot_popup_modal_title > a");
             HTML.beforeEnd(modalFooter,
@@ -948,7 +948,7 @@ class AppPageClass extends StorePageClass {
             });
         }
 
-        document.addEventListener("animationstart", es_initFSVButtons);
+        document.addEventListener("animationstart", initFSVButtons);
     }
 
     getFirstSubid() {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -566,6 +566,7 @@ class AppPageClass extends StorePageClass {
         this.addWishlistRemove();
         this.addUserNote();
         this.addNewQueueButton();
+        this.addFullscreenScreenshotView();
 
         this.addCoupon();
         this.addPrices();
@@ -910,6 +911,49 @@ class AppPageClass extends StorePageClass {
                 });
             });
         });
+    }
+
+    addFullscreenScreenshotView() {
+        function es_toggleFullScreen(event) {
+            if (!document.fullscreenElement) {
+                let element = event.target.closest(".screenshot_popup_modal_content");
+                element.requestFullscreen();
+            } else {
+                document.exitFullscreen();
+            }
+        }
+
+        function es_initFSVButton(event) {
+            if (event.animationName !== "es_screenshot_popup_modal_hook") return;
+
+            let modalFooter = document.querySelector(".screenshot_popup_modal_footer");
+            let fsvButton = document.createElement('div');
+            fsvButton.classList.add("btnv6_blue_hoverfade", "btn_medium", "es_screenshot_fullscreen_toggle");
+            fsvButton.innerHTML = "<i></i>";
+            let nextButton = modalFooter.querySelector(".next");
+            let nextButtonOffsetWidth = nextButton.offsetWidth;
+            if (nextButton.style.display === "none") {
+                nextButton.style.display = "";
+                nextButtonOffsetWidth = nextButton.offsetWidth;
+                nextButton.style.display = "none";
+            }
+            fsvButton.style.right = `calc(${nextButtonOffsetWidth}px + 0.5em)`;
+            fsvButton.addEventListener("click", es_toggleFullScreen);
+            modalFooter.appendChild(fsvButton);
+
+            let downloadButton = document.createElement('a');
+            downloadButton.classList.add("btnv6_blue_hoverfade", "btn_medium", "es_screenshot_download_btn");
+            let modalTitleLink = modalFooter.parentElement.querySelector(".screenshot_popup_modal_title > a");
+            downloadButton.title = modalTitleLink.textContent.trim();
+            downloadButton.innerHTML = "<i></i>";
+            downloadButton.style.right = `calc(${nextButtonOffsetWidth + fsvButton.offsetWidth}px + 1em)`;
+            downloadButton.addEventListener("click", () => {
+                modalTitleLink.click();
+            });
+            modalFooter.appendChild(downloadButton);
+        }
+
+        document.addEventListener("animationstart", es_initFSVButton);
     }
 
     getFirstSubid() {


### PR DESCRIPTION
## Simple button which activates fullscreen mode to comfortably view screenshots at store pages.


### Description:
Function from those which Valve should implement by themselfs long ago. Personally I use this feature for about 2 years now (as self-written userscript) and cannot imagine Steam-shoping without this. Because how else you can checkout how these games will look like at your own screen? Well, to be honest Steam client's Big Pucture can show store screenshots at fullscreen. But we are advanced users who use all those advanced functions in browser and we need those screenshots at fullscreen right here right now. There they are, right in this pull request.
_Wow! Felt like a marketer by writing this._


### Core features:
- No redudant JS code included!
Contained JS is necesarily only for including needed buttons and activating browsers built-in fullscreen mode. Whole hard work with images is done by native Steam's UI, for which was created fullscreen design by using CSS!
- In fullscreen mode 40% of screen from left is invisible "Previous" button. Now you dont need to aim at this filthy little button.
- In fullscreen mode buttons appears only when they are hovered. So all your screen used for maximum.
- Title with donwloading link is remade to the neat button at bottom. No need to spend screen for such things.


### Try out:
You can try basic implementation of it by installing userscript from here:
https://gist.github.com/thomas-ashcraft/00e58a0141fda12199d5e1fdee821ecf
Code is year old, partially updated just yesterday to avoid use of jQuery. But its universal and can run in almost any modern browser (except IE), even not updated ones for last few years.


### Technical notes:
Was tested in Firefox and Chrome. Working like a charm even at low RAM, bad connection, and awfully loaded 6 years old CPU.

My original pull request from may 2018 (https://github.com/jshackles/Enhanced_Steam/pull/1584) didn't merged because Enhanced Steam was in fact already dead back then.

At those moment major browsers still not yet completed Fullscreen API implementation. Which led to using dirty ways: additional hooks, additional JS code, or tonns of additional redudant CSS. Now all fullscreen requests and styling can be done easily by well documented cross-browser ways. At least for Firefox and Chrome.

So current brand new implementation of Steam screenshots fullscreen view contains only 2 JS dirty tricks.
1) "CSS keyframes hook" for detecting "screenshot_popup_modal" appearing in DOM.
2) "Click-through" for download button.

Those things can be theoretically avoided by complete rewriting Steam's internal function for screenshot_popup_modal. (```HighlightPlayer.prototype.ShowScreenshotPopup```)
The second one trick can be partially avoided by a lot of CSS. And nevertheless demands JS intervention for at least proper positioning.

There is still a room for improvements. For examples:
Pass thumbnails line to modal and/or fullscreen mode.
Make option for using fullscreen mode by default.
Place fullscreen view button right at app page, not just at modal popup.