### PR TITLE
exclude translation.steampowered.com steamcommunity/openid in the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -49,7 +49,8 @@
         "*://store.steampowered.com/join/*",
         "*://store.steampowered.com/api/*",
         "*://support.steampowered.com/*",
-        "*://help.steampowered.com/*"
+        "*://help.steampowered.com/*",
+        "*://translation.steampowered.com/*"
       ],
       "js": [
         "js/lib/DOMPurify/purify.js",
@@ -70,6 +71,7 @@
       ],
       "exclude_matches": [
         "*://steamcommunity.com/login/*",
+        "*://steamcommunity.com/openid/*",
         "*://steamcommunity.com/tradeoffer/*"
       ],
       "js": [

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,8 @@
         "*://store.steampowered.com/api/*",
         "*://support.steampowered.com/*",
         "*://help.steampowered.com/*",
-        "*://translation.steampowered.com/*"
+        "*://translation.steampowered.com/*",
+        "*://partner.steampowered.com/*"        
       ],
       "js": [
         "js/lib/DOMPurify/purify.js",


### PR DESCRIPTION
the former is incompatible with the extension and causes console errors, the latter is used on third-party logins through Steam