### PR TITLE
another attempt at fixing SteamRepCN option

### DIFF
--- a/js/options/options.js
+++ b/js/options/options.js
@@ -459,8 +459,8 @@ let Options = (function(){
             document.getElementById("regional_price_hideworld").style.display = "block";
         }
 
-        let language = Language.getCurrentSteamLanguage();
-        if (language !== "schinese" || language !== "tchinese") {
+        let language = SyncedStorage.get("language");
+        if (language !== "schinese" && language !== "tchinese") {
             let n = document.getElementById('profile_steamrepcn');
             if (n) {
                 // Hide SteamRepCN option if language isn't Chinese


### PR DESCRIPTION
fixes #208
I have no idea why this works but it does for me.
Steps I used to test the issue:
1. Log out of Steam
2. From the home page, change Steam language to `Traditional Chinese` OR `Simplified Chinese`
3. Open AS Settings, an option for `SteamRepCN` should appear
4. Change to other languages, and the `SteamRepCN` option should disappear