### PR TITLE
restore translations of language names in credits

### DIFF
--- a/js/options/options.js
+++ b/js/options/options.js
@@ -331,6 +331,12 @@ let Options = (function(){
                 }
             }
 
+            for (let lang of Object.keys(Localization.str.options.lang)) {
+                let node = document.querySelector(".language." + lang);
+                if (node) {
+                    node.textContent = Localization.str.options.lang[lang] + ":";
+                }
+            }
 
             let total = deepCount(Localization.str);
             for (let lang of Object.keys(Localization.str.options.lang)) {
@@ -602,8 +608,7 @@ let Options = (function(){
                 el.value = currency;
                 el.innerText = currency;
                 select.appendChild(el);
-            })
-            ;
+            });
     }
 
     self.init = async function() {


### PR DESCRIPTION
I just put the old code back, and fixed a trailing semicolon.