### PR TITLE
remove redundant information from warning_language

### DIFF
--- a/options.html
+++ b/options.html
@@ -265,8 +265,8 @@
                                 <option value="brazilian">Português-Brasil</option>
                                 <option value="russian">Русский</option>
                                 <option value="romanian">Română</option>
-                                <option value="schinese">汉语（简体字）</option>
-                                <option value="tchinese">漢語（繁體字）</option>
+                                <option value="schinese">汉语</option>
+                                <option value="tchinese">漢語</option>
                                 <option value="spanish">Español</option>
                                 <option value="latam">Español Latinoamericano</option>
                                 <option value="swedish">Svenska</option>


### PR DESCRIPTION
"Simplified" and "Traditional" (Chinese) is already provided in the translated text in brackets.