### PR TITLE
improve "Don't automatically filter guides by user language" option

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -3666,21 +3666,28 @@ let GuidesPageClass = (function(){
     GuidesPageClass.prototype.removeGuidesLanguageFilter = function() {
         if (!SyncedStorage.get("removeguideslanguagefilter")) { return; }
 
-        let language = Language.getCurrentSteamLanguage();
-        let regex = new RegExp(language, "i");
         let nodes = document.querySelectorAll("#rightContents .browseOption");
         for (let node of nodes) {
             let onclick = node.getAttribute("onclick");
 
-            if (regex.test(onclick)) {
-                node.removeAttribute("onclick"); // remove onclick, we have link anyway, why do they do this?
-                // node.setAttribute("onclick", onclick.replace(/requiredtags[^&]+&?/, ""))
+            if (onclick) {
+                //node.removeAttribute("onclick");
+                node.setAttribute("onclick", onclick.replace(/requiredtags(%5B0?%5D|\[\])=[^&]+/, "requiredtags[]=-1"));
             }
 
             let linkNode = node.querySelector("a");
-            if (regex.test(linkNode.href)) {
-                linkNode.href = linkNode.href.replace(/requiredtags[^&]+&?/, "");
-            }
+            //linkNode.href = linkNode.href.replace(/&requiredtags[^&]+/, "");
+            linkNode.href = linkNode.href.replace(/requiredtags(%5B0?%5D|\[\])=[^&]+/, "requiredtags[]=-1");
+        }
+
+        nodes = document.querySelectorAll(".guides_home_view_all_link > a");
+        for (let node of nodes) {
+            node.href = node.href.replace(/[&]requiredtags[^&]+/, "");
+        }
+
+        nodes = document.querySelectorAll(".guide_home_category_selection");
+        for (let node of nodes) {
+            node.href = node.href.replace(/(requiredtags[^&]+).*/, "$1");
         }
     };
 

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -3671,23 +3671,16 @@ let GuidesPageClass = (function(){
             let onclick = node.getAttribute("onclick");
 
             if (onclick) {
-                //node.removeAttribute("onclick");
-                node.setAttribute("onclick", onclick.replace(/requiredtags(%5B0?%5D|\[\])=[^&]+/, "requiredtags[]=-1"));
+                node.setAttribute("onclick", onclick.replace(/requiredtags[^&]+/, "requiredtags[]=-1"));
             }
 
             let linkNode = node.querySelector("a");
-            //linkNode.href = linkNode.href.replace(/&requiredtags[^&]+/, "");
-            linkNode.href = linkNode.href.replace(/requiredtags(%5B0?%5D|\[\])=[^&]+/, "requiredtags[]=-1");
+            linkNode.href = linkNode.href.replace(/requiredtags[^&]+/, "requiredtags[]=-1");
         }
 
-        nodes = document.querySelectorAll(".guides_home_view_all_link > a");
+        nodes = document.querySelectorAll(".guides_home_view_all_link > a, .guide_home_category_selection");
         for (let node of nodes) {
-            node.href = node.href.replace(/[&]requiredtags[^&]+/, "");
-        }
-
-        nodes = document.querySelectorAll(".guide_home_category_selection");
-        for (let node of nodes) {
-            node.href = node.href.replace(/(requiredtags[^&]+).*/, "$1");
+            node.href = node.href.replace(/&requiredtags[^&]+$/, "");
         }
     };
 


### PR DESCRIPTION
Resolves #553, needs more testing though.
Some notes:
1. The language tags are applied as listed in the LANGUAGE dropdown under FILTER BY CATEGORY, which differs from the values retrieved by `Language.getCurrentSteamLanguage();`
2. For the links in the BROWSE BY section, I found that if you remove the language tag from `href` or `onclick` or remove the attribute `onclick`, the links will sometimes require multiple clicks to work (especially on FireFox), and the user language tag can sometimes get added back after navigating multiple times. Setting the language tag here to `-1` (none specified) works better. I left the old code in comments for testing.