### PR TITLE
fix dlc checkboxes

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1844,10 +1844,13 @@ class AppPageClass extends StorePageClass {
              <div class='es_dlc_option' id='wl_dlc_check'>${Localization.str.select.wishlisted_dlc}</div>
              <div class='es_dlc_option' id='no_dlc_check'>${Localization.str.select.none}</div>`);
 
+        let change = new Event("change", {"bubbles": true});
+
         document.querySelector("#unowned_dlc_check").addEventListener("click", function () {
             let nodes = document.querySelectorAll(".game_area_dlc_section .game_area_dlc_row:not(.ds_owned) input:not(:checked)");
             for (let i=0, len=nodes.length; i<len; i++) {
                 nodes[i].checked = true;
+                nodes[i].dispatchEvent(change);
             }
         });
 
@@ -1855,6 +1858,7 @@ class AppPageClass extends StorePageClass {
             let nodes = document.querySelectorAll(".game_area_dlc_section .ds_wishlist input:not(:checked)");
             for (let i=0, len=nodes.length; i<len; i++) {
                 nodes[i].checked = true;
+                nodes[i].dispatchEvent(change);
             }
         });
 
@@ -1862,11 +1866,12 @@ class AppPageClass extends StorePageClass {
             let nodes = document.querySelectorAll(".game_area_dlc_section .game_area_dlc_row input:checked");
             for (let i=0, len=nodes.length; i<len; i++) {
                 nodes[i].checked = false;
+                nodes[i].dispatchEvent(change);
             }
         });
 
         HTML.beforeEnd(".game_area_dlc_section .gradientbg",
-            "<a id='es_dlc_option_button'>" + Localization.str.thewordoptions + " ▾</a>");
+            "<a id='es_dlc_option_button'>" + Localization.str.thewordoptions + " ▼</a>");
 
         document.querySelector("#es_dlc_option_button").addEventListener("click", function() {
             document.querySelector("#es_dlc_option_panel")
@@ -1874,15 +1879,16 @@ class AppPageClass extends StorePageClass {
 
             let button = document.querySelector("#es_dlc_option_button");
 
-            button.textContent = (button.textContent.match("▾")
-                ? Localization.str.thewordoptions + " ▴"
-                : Localization.str.thewordoptions + " ▾");
+            button.textContent = (button.textContent.match("▼")
+                ? Localization.str.thewordoptions + " ▲"
+                : Localization.str.thewordoptions + " ▼");
         });
 
         document.querySelector(".game_area_dlc_section").addEventListener("change", function(e){
             if (!e.target.classList.contains("es_dlc_selection")) { return; }
 
             let cartNode = document.querySelector("#es_selected_cart");
+            cartNode.innerHTML = "";
 
             let inputAction = document.createElement("input");
             inputAction.type = "hidden";

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1807,10 +1807,10 @@ class AppPageClass extends StorePageClass {
         let expandedNode = document.querySelector("#game_area_dlc_expanded");
 
         if (expandedNode) {
-            HTML.afterEnd(expandedNode,  "<div class='game_purchase_action game_purchase_action_bg' style='float: left; margin-top: 4px; margin-bottom: 10px; display: none;' id='es_selected_btn'><div class='btn_addtocart'><a class='btnv6_green_white_innerfade btn_medium'><span>" + Localization.str.add_selected_dlc_to_cart + "</span></a></div></div>");
+            HTML.afterEnd(expandedNode, `<div class='game_purchase_action game_purchase_action_bg' style='float: left; margin-top: 4px; margin-bottom: 10px; display: none;' id='es_selected_btn'><div class='btn_addtocart'><a class='btnv6_green_white_innerfade btn_medium'><span>${Localization.str.add_selected_dlc_to_cart}</span></a></div></div>`);
             HTML.afterEnd(".game_area_dlc_section", "<div style='clear: both;'></div>");
         } else {
-            HTML.afterEnd(".gameDlcBlocks", "<div class='game_purchase_action game_purchase_action_bg' style='float: left; margin-top: 4px; display: none;' id='es_selected_btn'><div class='btn_addtocart'><a class='btnv6_green_white_innerfade btn_medium'><span>" + Localization.str.add_selected_dlc_to_cart + "</span></a></div></div>");
+            HTML.afterEnd(".gameDlcBlocks", `<div class='game_purchase_action game_purchase_action_bg' style='float: left; margin-top: 4px; display: none;' id='es_selected_btn'><div class='btn_addtocart'><a class='btnv6_green_white_innerfade btn_medium'><span>${Localization.str.add_selected_dlc_to_cart}</span></a></div></div>`);
         }
 
         let form = document.createElement("form");
@@ -1821,7 +1821,7 @@ class AppPageClass extends StorePageClass {
 
         let button = document.querySelector("#es_selected_btn");
         button.insertAdjacentElement("beforebegin", form);
-        button.addEventListener("click", function(){
+        button.addEventListener("click", function() {
             document.querySelector("form[name=add_selected_dlc_to_cart]").submit();
         });
 
@@ -1831,7 +1831,7 @@ class AppPageClass extends StorePageClass {
 
                 HTML.afterBegin(
                     dlc.querySelector(".game_area_dlc_name"),
-                    "<input type='checkbox' class='es_dlc_selection' style='cursor: default;' id='es_select_dlc_" + value + "' value='" + value + "'><label for='es_select_dlc_" + value + "' style='background-image: url( " + ExtensionLayer.getLocalUrl("img/check_sheet.png") + ");'></label>");
+                    `<input type='checkbox' class='es_dlc_selection' style='cursor: default;' id='es_select_dlc_${value}' value='${value}'><label for='es_select_dlc_${value}' style='background-image: url(${ExtensionLayer.getLocalUrl("img/check_sheet.png")})'></label>`);
             } else {
                 dlc.querySelector(".game_area_dlc_name").style.marginLeft = "23px";
             }
@@ -1846,32 +1846,32 @@ class AppPageClass extends StorePageClass {
 
         let change = new Event("change", {"bubbles": true});
 
-        document.querySelector("#unowned_dlc_check").addEventListener("click", function () {
+        document.querySelector("#unowned_dlc_check").addEventListener("click", function() {
             let nodes = document.querySelectorAll(".game_area_dlc_section .game_area_dlc_row:not(.ds_owned) input:not(:checked)");
-            for (let i=0, len=nodes.length; i<len; i++) {
-                nodes[i].checked = true;
-                nodes[i].dispatchEvent(change);
+            for (let node of nodes) {
+                node.checked = true;
+                node.dispatchEvent(change);
             }
         });
 
-        document.querySelector("#wl_dlc_check").addEventListener("click", function(){
+        document.querySelector("#wl_dlc_check").addEventListener("click", function() {
             let nodes = document.querySelectorAll(".game_area_dlc_section .ds_wishlist input:not(:checked)");
-            for (let i=0, len=nodes.length; i<len; i++) {
-                nodes[i].checked = true;
-                nodes[i].dispatchEvent(change);
+            for (let node of nodes) {
+                node.checked = true;
+                node.dispatchEvent(change);
             }
         });
 
-        document.querySelector("#no_dlc_check").addEventListener("click", function(){
+        document.querySelector("#no_dlc_check").addEventListener("click", function() {
             let nodes = document.querySelectorAll(".game_area_dlc_section .game_area_dlc_row input:checked");
-            for (let i=0, len=nodes.length; i<len; i++) {
-                nodes[i].checked = false;
-                nodes[i].dispatchEvent(change);
+            for (let node of nodes) {
+                node.checked = false;
+                node.dispatchEvent(change);
             }
         });
 
         HTML.beforeEnd(".game_area_dlc_section .gradientbg",
-            "<a id='es_dlc_option_button'>" + Localization.str.thewordoptions + " ▼</a>");
+            `<a id='es_dlc_option_button'>${Localization.str.thewordoptions} ▼</a>`);
 
         document.querySelector("#es_dlc_option_button").addEventListener("click", function() {
             document.querySelector("#es_dlc_option_panel")
@@ -1880,11 +1880,11 @@ class AppPageClass extends StorePageClass {
             let button = document.querySelector("#es_dlc_option_button");
 
             button.textContent = (button.textContent.match("▼")
-                ? Localization.str.thewordoptions + " ▲"
-                : Localization.str.thewordoptions + " ▼");
+                ? `${Localization.str.thewordoptions} ▲`
+                : `${Localization.str.thewordoptions} ▼`);
         });
 
-        document.querySelector(".game_area_dlc_section").addEventListener("change", function(e){
+        document.querySelector(".game_area_dlc_section").addEventListener("change", function(e) {
             if (!e.target.classList.contains("es_dlc_selection")) { return; }
 
             let cartNode = document.querySelector("#es_selected_cart");
@@ -1904,15 +1904,14 @@ class AppPageClass extends StorePageClass {
             cartNode.appendChild(inputSessionId);
 
             let nodes = document.querySelectorAll(".es_dlc_selection:checked");
-            for (let i=0, len=nodes.length; i<len; i++) {
-                let node = nodes[i];
+            for (let node of nodes) {
 
-                let input = document.createElement("input");
-                input.setAttribute("type", "hidden");
-                input.setAttribute("name", "subid[]");
-                input.setAttribute("value", node.value);
+                let inputSubId = document.createElement("input");
+                inputSubId.setAttribute("type", "hidden");
+                inputSubId.setAttribute("name", "subid[]");
+                inputSubId.setAttribute("value", node.value);
 
-                cartNode.insertAdjacentElement("beforeend", input);
+                cartNode.insertAdjacentElement("beforeend", inputSubId);
             }
 
             let button = document.querySelector("#es_selected_btn");


### PR DESCRIPTION
Some fixes regarding DLC checkboxes:
1. Clicking "Select Unowned DLC" etc. under Options doesn't toggle the "add items to cart" button
2. Selecting and deselecting the checkboxes multiple times will cause items to fail to add to cart
3. Switch to using the larger arrow icons from addReviewToggleButton()