### PR TITLE
fix some customizer issues

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2080,11 +2080,10 @@ class AppPageClass extends StorePageClass {
         let workshop = document.querySelector("[href^='https://steamcommunity.com/workshop/browse']");
         let morelikethis = document.querySelector("#recommended_block h2");
 
-        setTimeout(() => {
         let customizer = new Customizer("customize_apppage");
         customizer
             .add("recommendedbycurators", ".steam_curators_block")
-            .add("recentupdates", ".early_access_announcements")
+            .add("recentupdates", "#events_root", Localization.str.apppage_recentupdates)
             .add("reviews", "#game_area_reviews")
             .add("about", "[data-parent-of='#game_area_description']")
             .add("contentwarning", "[data-parent-of='#game_area_content_descriptors']")
@@ -2102,7 +2101,6 @@ class AppPageClass extends StorePageClass {
 
         customizer.build();
         document.querySelector(".purchase_area_spacer").style.height = "auto";
-        }, 1000);
     }
 
     addReviewToggleButton() {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2086,6 +2086,7 @@ class AppPageClass extends StorePageClass {
         let workshop = document.querySelector("[href^='https://steamcommunity.com/workshop/browse']");
         let morelikethis = document.querySelector("#recommended_block h2");
 
+        setTimeout(() => {
         let customizer = new Customizer("customize_apppage");
         customizer
             .add("recommendedbycurators", ".steam_curators_block")
@@ -2096,7 +2097,7 @@ class AppPageClass extends StorePageClass {
             .add("steamchart", "#steam-charts")
             .add("surveys", "#performance_survey")
             .add("steamspy", "#steam-spy")
-            .add("sysreq", "[data-parent-of='.sys_req")
+            .add("sysreq", "[data-parent-of='.sys_req']")
             .add("legal", "[data-parent-of='#game_area_legal']", Localization.str.apppage_legal)
             .add("moredlcfrombasegame", "#moredlcfrombasegame_block")
             .add("franchise", "#franchise_block", Localization.str.apppage_franchise)
@@ -2107,6 +2108,7 @@ class AppPageClass extends StorePageClass {
 
         customizer.build();
         document.querySelector(".purchase_area_spacer").style.height = "auto";
+        }, 1000);
     }
 
     addReviewToggleButton() {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1119,9 +1119,6 @@ class AppPageClass extends StorePageClass {
                                 <div class='chart-footer'>${Localization.str.read_more_reviews} <a href='${data.url}?utm_source=enhanced-steam-itad&utm_medium=reviews' target='_blank'>OpenCritic.com</a></div>
                             </div>
                         </div>`);
-
-                    if (!SyncedStorage.get("customize_apppage").reviews) {
-                        document.querySelector("#game_area_reviews").style.display = "none";
                     }
                 }
 
@@ -1229,9 +1226,6 @@ class AppPageClass extends StorePageClass {
                     <h2>${Localization.str.reviews}</h2>
                     <div id="es_youtube_reviews"></div>
                 </div>`);
-
-            if (!SyncedStorage.get("customize_apppage").reviews) {
-                document.querySelector("#game_area_reviews").style.display = "none";
             }
         } else {
             HTML.beforeEnd(reviewsNode, '<div id="es_youtube_reviews"></div>');

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -157,6 +157,7 @@
     "most_drops": "Most Drops",
     "badge_foil_progress": "View Foil Badge Progress",
     "net_gain": "Net gain:",
+    "apppage_recentupdates": "Recent Events & Announcements",
     "apppage_legal": "Legal Information",
     "apppage_franchise": "Franchise",
     "bug_feature": "Report Bug / Suggest Feature",


### PR DESCRIPTION
1. After unchecking "Recent Updates" from the customizer and reloading the page, the option disappears. Setting a timeout for the customizer seems to fix it.
2. On apps that have the "Reviews" section created by AS, after unchecking the option from the customizer and reloading the page, the option disappears.