### PR TITLE
fix missing checkbox image on firefox

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -61,7 +61,7 @@
   display: inline-block;
   width: 14px;
   height: 14px;
-  background-image: url(/public/images/v6/customize_checkboxes.png);
+  background-image: url('https://steamstore-a.akamaihd.net/public/images/v6/customize_checkboxes.png');
   background-position: 0px 0px;
 }
 


### PR DESCRIPTION
checkbox image is missing on firefox for some reason...
![註解 2019-10-25 015338](https://user-images.githubusercontent.com/54083835/67512047-9bd89580-f6ca-11e9-9127-0e5dac5738c0.jpg)