### PR TITLE
Add new sections to customizer

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3879,7 +3879,7 @@ let StoreFrontPageClass = (function(){
                 .add("popularvrgames", ".best_selling_vr_ctn")
                 .add("homepagetabs", ".tab_container", Localization.str.homepage_tabs)
                 .add("gamesstreamingnow", ".live_streams_ctn")
-                .add("updatesandoffers", ".marketingmessage_area")
+                .add("updatesandoffers", ".marketingmessage_area", "", true)
                 .add("homepagesidebar", ".home_page_gutter", Localization.str.homepage_sidebar)
                 .add("topnewreleases", ".top_new_releases", Localization.str.homepage_topnewreleases);
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3866,7 +3866,7 @@ let StoreFrontPageClass = (function(){
             let browsesteam = document.querySelector(".big_buttons.home_page_content");
             let recentlyupdated = document.querySelector(".recently_updated_block");
             let under = document.querySelector("[class*='specials_under']");
-            let steamlabs = document.querySelector(".labs_title");
+            let steamlabs = document.querySelector(".labs_cluster h1");
 
             let customizer = new Customizer("customize_frontpage");
             customizer
@@ -3887,7 +3887,7 @@ let StoreFrontPageClass = (function(){
             if (browsesteam) customizer.add("browsesteam", browsesteam.parentElement);
             if (recentlyupdated) customizer.add("recentlyupdated", recentlyupdated.parentElement);
             if (under) customizer.add("under", under.parentElement.parentElement);
-            if (steamlabs) customizer.add("steamlabs", steamlabs.parentElement.parentElement, steamlabs.textContent);
+            if (steamlabs) customizer.add("steamlabs", ".labs_cluster", steamlabs.textContent);
 
             let dynamicNodes = Array.from(document.querySelectorAll(".home_page_body_ctn .home_ctn:not(.esi-customizer)"));
             for (let i = 0; i < dynamicNodes.length; ++i) {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3866,6 +3866,7 @@ let StoreFrontPageClass = (function(){
             let browsesteam = document.querySelector(".big_buttons.home_page_content");
             let recentlyupdated = document.querySelector(".recently_updated_block");
             let under = document.querySelector("[class*='specials_under']");
+            let steamlabs = document.querySelector(".labs_title");
 
             let customizer = new Customizer("customize_frontpage");
             customizer
@@ -3879,12 +3880,14 @@ let StoreFrontPageClass = (function(){
                 .add("homepagetabs", ".tab_container", Localization.str.homepage_tabs)
                 .add("gamesstreamingnow", ".live_streams_ctn")
                 .add("updatesandoffers", ".marketingmessage_area")
-                .add("homepagesidebar", ".home_page_gutter", Localization.str.homepage_sidebar);
+                .add("homepagesidebar", ".home_page_gutter", Localization.str.homepage_sidebar)
+                .add("topnewreleases", ".top_new_releases", Localization.str.homepage_topnewreleases);
 
             if (specialoffers) customizer.add("specialoffers", specialoffers.parentElement);
             if (browsesteam) customizer.add("browsesteam", browsesteam.parentElement);
             if (recentlyupdated) customizer.add("recentlyupdated", recentlyupdated.parentElement);
             if (under) customizer.add("under", under.parentElement.parentElement);
+            if (steamlabs) customizer.add("steamlabs", steamlabs.parentElement.parentElement, steamlabs.textContent);
 
             let dynamicNodes = Array.from(document.querySelectorAll(".home_page_body_ctn .home_ctn:not(.esi-customizer)"));
             for (let i = 0; i < dynamicNodes.length; ++i) {

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -71,6 +71,7 @@
     "starting_at": "Starting at: __price__",
     "hardwareads": "Hardware Advertising",
     "homepage_tabs": "Homepage Tabs",
+    "homepage_topnewreleases": "Top Steam Releases",
     "tag_categories": "Tag categories",
     "discounts": "Discounts",
     "new_and_upcoming": "New & Upcoming",


### PR DESCRIPTION
Add some new homepage sections to the customizer.
For Steam Labs Recommendations, the option hides all experiments, but I guess it can be set up to hide individual experiments as well if there is demand.

edit: also fixed the updates and offers option not showing -- the section turns visible only after you scroll down