### PR TITLE
Fix horizontal scrollbar on homepage

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3849,7 +3849,6 @@ let StoreFrontPageClass = (function(){
                 </div>
             </div>`);
 
-        document.querySelector(".home_page_body_ctn").style.overflow = "visible";
         document.querySelector("#es_customize_btn").addEventListener("click", function(e){
             e.target.classList.toggle("active");
         });


### PR DESCRIPTION
Fix #537 
This style was not present in ES, and I'm not sure what it's supposed to fix, but it seems to be the cause of the issue.
ES had the following styles, but I'm not sure what they are for either:
`$(".home_page_body_ctn:first").css("min-height", "400px");`
`$(".has_takeover").css("min-height", "600px");`