### PR TITLE
Improve homepage customizer options

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -11,7 +11,7 @@ class Customizer {
         if (!textNode) return "";
         let str = "";
         for (let node of textNode.childNodes) {
-            if (node.nodeType === 3) {
+            if (node.nodeType === Node.TEXT_NODE) {
                 str += node.textContent.trim();
             }
         }
@@ -74,12 +74,10 @@ class Customizer {
     }
 
     addDynamic(node) {
-        let text = this._textValue(node);
-        if (text === "") { return; }
+        let text = this._textValue(node).toLowerCase();
+        if (text === "") return;
 
-        let name = text.toLowerCase();
-
-        this.add(`dynamic_${name}`, node, text);
+        this.add(`dynamic_${text}`, node, text);
     }
 
     build() {
@@ -98,10 +96,10 @@ class Customizer {
                 let text = element.dataset.es_text;
 
                 HTML.beforeEnd("#es_customize_btn .home_viewsettings_popup",
-                `<div class="home_viewsettings_checkboxrow ellipsis" id="${name}">
-                    <div class="home_viewsettings_checkbox ${state ? `checked` : ``}"></div>
-                    <div class="home_viewsettings_label">${text}</div>
-                </div>`);
+                    `<div class="home_viewsettings_checkboxrow ellipsis" id="${name}">
+                        <div class="home_viewsettings_checkbox ${state ? 'checked' : ''}"></div>
+                        <div class="home_viewsettings_label">${text}</div>
+                    </div>`);
 
                 customizerEntries.set(name, [element]);
             }            
@@ -112,10 +110,10 @@ class Customizer {
             checkboxrow.addEventListener("click", e => {
                 let state = !checkboxrow.querySelector(".checked");
 
-                elements.forEach(element => {
+                for (let element of elements) {
                     element.classList.toggle("esi-shown", state);
                     element.classList.toggle("esi-hidden", !state);
-                });
+                }
 
                 e.target.closest(".home_viewsettings_checkboxrow")
                     .querySelector(".home_viewsettings_checkbox").classList.toggle("checked", state);

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -65,22 +65,12 @@ class Customizer {
         for (let element of elements) {
             element.classList.toggle("esi-shown", state);
             element.classList.toggle("esi-hidden", !state);
-            element.classList.add("esi-customizer"); // for dynamic entries on home page
+            element.classList.add("esi-customizer");
             element.dataset.es_name = name;
             element.dataset.es_text = text;
         }
 
         return this;
-    };
-
-    addDynamic(titleNode, targetNode) {
-        let textValue = this._textValue(titleNode);
-
-        console.warn("Node with textValue %s is not recognized!", textValue);
-        let option = textValue.toLowerCase().replace(/[^a-z]*/g, "");
-        if (option === "") { return; }
-
-        this.add("dynamic_" + option, targetNode, textValue);
     }
 
     build() {
@@ -3888,17 +3878,6 @@ let StoreFrontPageClass = (function(){
             if (browsesteam) customizer.add("browsesteam", browsesteam.parentElement);
             if (recentlyupdated) customizer.add("recentlyupdated", recentlyupdated.parentElement);
             if (under) customizer.add("under", under.parentElement.parentElement);
-
-            let dynamicNodes = Array.from(document.querySelectorAll(".home_page_body_ctn .home_ctn:not(.esi-customizer)"));
-            for (let i = 0; i < dynamicNodes.length; ++i) {
-                let node = dynamicNodes[i];
-                if (node.querySelector(".esi-customizer") || node.style.display === "none") { continue; }
-
-                let headerNode = node.querySelector(".home_page_content > h2,.carousel_container > h2");
-                if (!headerNode) { continue; }
-
-                customizer.addDynamic(headerNode, node);
-            }
 
             customizer.build();
         }, 1000);

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -7,15 +7,16 @@ class Customizer {
     }
 
     _textValue(node) {
-        if (!node) return '';
+        let textNode = node.querySelector("h1, h2");
+        if (!textNode) return "";
         let str = "";
-        for (node = node.firstChild; node; node = node.nextSibling) {
-            if (node.nodeType === 3 || (node.nodeType === 1 && node.tagName === "A")) { // Special case for Steam curators
+        for (let node of textNode.childNodes) {
+            if (node.nodeType === 3) {
                 str += node.textContent.trim();
             }
         }
         return str;
-    };
+    }
 
     _updateValue(name, value) {
         this.settings[name] = value;
@@ -46,14 +47,14 @@ class Customizer {
         let isValid = false;
 
         elements.forEach((element, i) => {
-            if (getComputedStyle(element).display === "none" && !forceShow) {
+            if (element.style.display === "none" && !forceShow) {
                 elements.splice(i, 1);
                 return;
             }
     
-            if (!text) {
-                text = (typeof text === "string" && text) || this._textValue(element.querySelector(".home_section_title, h2")).toLowerCase();
-                if (!text) return;
+            if (typeof text !== "string" || text === "") {
+                text = this._textValue(element).toLowerCase();
+                if (text === "") return;
             }
 
             isValid = true;
@@ -3872,13 +3873,15 @@ let StoreFrontPageClass = (function(){
                 .add("featuredrecommended", ".home_cluster_ctn")
                 .add("trendingamongfriends", ".friends_recently_purchased")
                 .add("discoveryqueue", ".discovery_queue_ctn")
-                .add("curators", ".steam_curators_ctn")
-                .add("morecuratorrecommendations", ".apps_recommended_by_curators_ctn")
+                .add("curators", ".steam_curators_ctn", Localization.str.homepage_curators)
+                .add("morecuratorrecommendations", ".apps_recommended_by_curators_ctn", Localization.str.homepage_curators)
                 .add("fromdevelopersandpublishersthatyouknow", ".recommended_creators_ctn")
                 .add("popularvrgames", ".best_selling_vr_ctn")
                 .add("homepagetabs", ".tab_container", Localization.str.homepage_tabs)
-                .add("gamesstreamingnow", ".live_streams_ctn")
-                .add("updatesandoffers", ".marketingmessage_area")
+                .add("gamesstreamingnow", ".live_streams_ctn", "", true)
+                .add("updatesandoffers", ".marketingmessage_area", "", true)
+                .add("topnewreleases", ".top_new_releases", Localization.str.homepage_topnewreleases)
+                .add("steamlabs", ".labs_cluster")
                 .add("homepagesidebar", ".home_page_gutter", Localization.str.homepage_sidebar);
 
             if (specialoffers) customizer.add("specialoffers", specialoffers.parentElement);

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -7,7 +7,7 @@ class Customizer {
     }
 
     _textValue(node) {
-        let textNode = node.querySelector("h1, h2");
+        let textNode = node.querySelector("h1, h2, .home_title, .home_section_title");
         if (!textNode) return "";
         let str = "";
         for (let node of textNode.childNodes) {
@@ -47,7 +47,7 @@ class Customizer {
         let isValid = false;
 
         elements.forEach((element, i) => {
-            if (element.style.display === "none" && !forceShow) {
+            if (getComputedStyle(element).display === "none" && !forceShow) {
                 elements.splice(i, 1);
                 return;
             }
@@ -71,6 +71,15 @@ class Customizer {
         }
 
         return this;
+    }
+
+    addDynamic(node) {
+        let text = this._textValue(node);
+        if (text === "") { return; }
+
+        let name = text.toLowerCase();
+
+        this.add(`dynamic_${name}`, node, text);
     }
 
     build() {
@@ -3878,6 +3887,13 @@ let StoreFrontPageClass = (function(){
             if (browsesteam) customizer.add("browsesteam", browsesteam.parentElement);
             if (recentlyupdated) customizer.add("recentlyupdated", recentlyupdated.parentElement);
             if (under) customizer.add("under", under.parentElement.parentElement);
+
+            let dynamicNodes = document.querySelectorAll(".home_page_body_ctn .home_ctn:not(.esi-customizer), .home_pagecontent_ctn");
+            for (let node of dynamicNodes) {
+                if (node.closest(".esi-customizer") || node.querySelector(".esi-customizer") || node.style.display === "none") { continue; }
+
+                customizer.addDynamic(node);
+            }
 
             customizer.build();
         }, 1000);

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -118,6 +118,8 @@
     "using_store": "You are using the Steam store for the __current__ region.",
     "volume_sold_last_24": "Volume: __sold__ sold in the last 24 hours",
     "sold_last_24": "__sold__ sold in the last 24 hours",
+    "homepage_curators": "Steam Curator Recommendations",
+    "homepage_topnewreleases": "Top Steam Releases",
     "homepage_sidebar": "Sidebar",
     "drop_calc": "Click here to calculate drops remaining",
     "price": "Price",


### PR DESCRIPTION
1. Add some new homepage sections to the customizer. For Steam Labs Recommendations, the option hides all experiments, but I guess it can be set up to hide individual experiments as well if there is demand.
2. Fixed "Updates and Offers" & "Games Streaming Now" options not showing. The sections turns visible only after you scroll further down.
3. Simplify the customizer code a bit.
4. ~~Remove addDynamic method since all current options are already manually added. IMO it's better to manually add options and check if they work properly when new ones pop up.~~
Fixed and simplified addDynamic method. I suppose it can be useful for sale events.