### PR TITLE
Improve regional price mouseover behaviour

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -1872,9 +1872,8 @@ input[type=checkbox].es_dlc_selection:checked + label {
   height: auto;
   min-height: 136px;
 }
-.es_regional_prices:not(.es_regional_always) .game_purchase_action_bg {
+.es_regional_prices:not(.es_regional_always) .es_regional_onmouse {
   cursor: help;
-  position: relative;
 }
 .es_regional_icon {
   padding-left: 23px !important;

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -473,11 +473,11 @@ class StorePageClass {
                     purchaseArea.classList.add("es_regional_always");
                 } else {
                     let priceNode = node.querySelector(".price,.discount_prices");
-                    priceNode.insertAdjacentElement("afterend", pricingDiv);
-                    priceNode.parentNode.classList.add("es_regional_onmouse");
+                    priceNode.insertAdjacentElement("beforeend", pricingDiv);
+                    priceNode.classList.add("es_regional_onmouse");
 
                     if (!SyncedStorage.get("regional_hideworld")) {
-                        node.querySelector(".price,.discount_prices").classList.add("es_regional_icon")
+                        priceNode.classList.add("es_regional_icon");
                     }
                 }
             })


### PR DESCRIPTION
Make it so that the "on price mouseover" behaviour is actually on the prices, instead of extending to the purchase button and discount %.