### PR TITLE
Exclude "*://steamcommunity.com/chat/*" in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,7 @@
       "exclude_matches": [
         "*://steamcommunity.com/login/*",
         "*://steamcommunity.com/openid/*",
+        "*://steamcommunity.com/chat/*",
         "*://steamcommunity.com/tradeoffer/*"
       ],
       "js": [


### PR DESCRIPTION
Loading this page made AS crash, because it couldn't find the global menu element. I could add a check for that, but I don't think any code in AS is meant for the chat, so I guess it's better to exclude it.