### PR TITLE
Restore missing translation string "lowest_price"

### DIFF
--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -58,6 +58,7 @@
     "events": "Events",
     "translation": "Translation",
     "lowest": "Lowest",
+    "lowest_price": "Current Lowest Price:",
     "view_badge_progress": "View badge progress",
     "badge_progress": "Badge Progress",
     "sales_total": "Sales total:",


### PR DESCRIPTION
This was removed in https://github.com/tfedor/AugmentedSteam/commit/5cb99e3e342b2b4a47e261d6a21e785b2de76d31, but it's still used:
https://github.com/tfedor/AugmentedSteam/blob/bc096d5bd26717cbba74789646805d9aaba45940/js/content/community.js#L2706