### PR TITLE
Fix devpub text overflow hidden

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1493,6 +1493,12 @@ class AppPageClass extends StorePageClass {
             linkNode.href = `https://store.steampowered.com/search/?${name}=${encodeURIComponent(value)}`;
             HTML.afterEnd(linkNode, ` (<a href="${homepageLink.href}">${Localization.str.options.homepage}</a>)`);
         }
+
+        for (let moreBtn of document.querySelectorAll(".dev_row > .more_btn")) {
+            if (moreBtn) { moreBtn.remove(); }
+        }
+
+        ExtensionLayer.runInPageContext(() => CollapseLongStrings(".dev_row .summary.column"));
     }
 
     async addSupport() {


### PR DESCRIPTION
After adding dev/pub homepage links, the text sometimes overflows and remains hidden. Fix this by adding the "+" button implemented by Steam.
Store pages for testing:
https://store.steampowered.com/app/289070/Sid_Meiers_Civilization_VI/
https://store.steampowered.com/app/845880/Touhou_Scarlet_Curiosity/