### PR TITLE
Improve drm warnings

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -635,7 +635,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
   display: table-cell;
   vertical-align: middle;
   line-height: normal;
-  padding-left: 15px;
+  padding: 0 15px;
 }
 
 #es-lightbox {

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -227,12 +227,12 @@ class StorePageClass {
         let drm = false;
         let drmString = "";
         if (drmNames.length > 0) {
-            drmString += `(${drmNames.join(", ")})`;
+            drmString = `(${drmNames.join(", ")})`;
             drm = true;
         } else { // Detect other DRM on app pages
             let drmNode = document.querySelector("#category_block > .DRM_notice");
             if (drmNode) {
-                drmString += drmNode.innerHTML.replace("<br>", ", ").trim();
+                drmString = drmNode.innerHTML.replace("<br>", ", ").trim();
                 drm = /\b(drm|account)\b/i.test(drmString);
             }
         }

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -213,6 +213,9 @@ class StorePageClass {
         // EA origin detection
         let origin = text.includes("origin client");
 
+        // Microsoft Xbox Live account detection
+        let xbox = text.includes("xbox live");
+
         let drmNames = [];
         if (gfwl) { drmNames.push("Games for Windows Live"); }
         if (uplay) { drmNames.push("Ubisoft Uplay"); }
@@ -223,6 +226,7 @@ class StorePageClass {
         if (kalypso) { drmNames.push("Kalypso Launcher"); }
         if (denuvo) { drmNames.push("Denuvo Anti-tamper"); }
         if (origin) { drmNames.push("EA Origin"); }
+        if (xbox) { drmNames.push("Microsoft Xbox Live"); }
 
         let drm = false;
         let drmString;

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -225,15 +225,29 @@ class StorePageClass {
         if (origin) { drmNames.push("EA Origin"); }
 
         let drm = false;
-        let drmString = "";
+        let drmString;
+        let regex = /\b(drm|account|steam)\b/i;
         if (drmNames.length > 0) {
             drmString = `(${drmNames.join(", ")})`;
             drm = true;
-        } else { // Detect other DRM on app pages
-            let drmNode = document.querySelector("#category_block > .DRM_notice");
-            if (drmNode) {
-                drmString = drmNode.innerHTML.replace("<br>", ", ").trim();
-                drm = /\b(drm|account)\b/i.test(drmString);
+        } else { // Detect other DRM
+            if (this.isAppPage()) {
+                for (let node of document.querySelectorAll("#category_block > .DRM_notice")) {
+                    let text = node.textContent;
+                    if (text.match(regex)) {
+                        drmString = text;
+                        drm = true;
+                        break;
+                    }
+                }
+            }
+            if (this.isSubPage()) {
+                let node = document.querySelector(".game_details .details_block > p > b:last-of-type");
+                let text = node.textContent + node.nextSibling.textContent;
+                if (text.match(regex)) {
+                    drmString = text;
+                    drm = true;
+                }
             }
         }
 
@@ -244,7 +258,7 @@ class StorePageClass {
         )) { drm = false; }
 
         if (drm) {
-            let warnString = "";
+            let warnString;
             if (drmNames.length > 0) {
                 warnString = this.isAppPage() ? Localization.str.drm_third_party : Localization.str.drm_third_party_sub;
                 warnString = warnString.replace("__drmlist__", drmString);

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -210,6 +210,9 @@ class StorePageClass {
         // Denuvo Antitamper detection
         let denuvo = text.includes("denuvo");
 
+        // EA origin detection
+        let origin = text.includes("origin client");
+
         let drmNames = [];
         if (gfwl) { drmNames.push("Games for Windows Live"); }
         if (uplay) { drmNames.push("Ubisoft Uplay"); }
@@ -219,6 +222,7 @@ class StorePageClass {
         if (rockstar) { drmNames.push("Rockstar Social Club"); }
         if (kalypso) { drmNames.push("Kalypso Launcher"); }
         if (denuvo) { drmNames.push("Denuvo Anti-tamper"); }
+        if (origin) { drmNames.push("EA Origin"); }
 
         let drm = false;
         let drmString = "";

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -171,53 +171,52 @@ class StorePageClass {
 
         let text = "";
         for (let node of document.querySelectorAll(".game_area_sys_req, #game_area_legal, .game_details, .DRM_notice")) {
-            text += node.innerHTML;
+            text += node.textContent.toLowerCase();
         }
-        let uppercased = text.toUpperCase();
 
         // Games for Windows Live detection
         let gfwl =
-               uppercased.includes("GAMES FOR WINDOWS LIVE")
-            || uppercased.includes("GAMES FOR WINDOWS - LIVE")
-            || text.includes("Online play requires log-in to Games For Windows")
-            || text.includes("INSTALLATION OF THE GAMES FOR WINDOWS LIVE SOFTWARE")
-            || text.includes("Multiplayer play and other LIVE features included at no charge")
+               text.includes("games for windows live")
+            || text.includes("games for windows - live")
+            || text.includes("online play requires log-in to games for windows")
+            || text.includes("installation of the games for windows live software")
+            || text.includes("multiplayer play and other live features included at no charge")
             || text.includes("www.gamesforwindows.com/live");
 
         // Ubisoft Uplay detection
         let uplay =
-               text.includes("Uplay")
-            || text.includes("Ubisoft Account");
+               text.includes("uplay")
+            || text.includes("ubisoft account");
 
         // Securom detection
-        let securom = text.includes("SecuROM");
+        let securom = text.includes("securom");
 
         // Tages detection
         let tages =
-                text.match(/\b(tages|solidshield)\b/i)
-            && !text.match(/angebote des tages/i);
+                text.match(/\b(tages|solidshield)\b/)
+            && !text.match(/angebote des tages/);
 
         // Stardock account detection
-        let stardock = text.includes("Stardock account");
+        let stardock = text.includes("stardock account");
 
         // Rockstar social club detection
         let rockstar =
-               text.includes("Rockstar Social Club")
-            || text.includes("Rockstar Games Social Club");
+               text.includes("rockstar social club")
+            || text.includes("rockstar games social club");
 
         // Kalypso Launcher detection
-        let kalypso = text.includes("Requires a Kalypso account");
+        let kalypso = text.includes("requires a kalypso account");
 
         // Denuvo Antitamper detection
-        let denuvo = text.match(/\bdenuvo\b/i);
+        let denuvo = text.includes("denuvo");
 
         let drmNames = [];
-        if (gfwl) { drmNames.push('Games for Windows Live'); }
-        if (uplay) { drmNames.push('Ubisoft Uplay'); }
-        if (securom) { drmNames.push('SecuROM'); }
-        if (tages) { drmNames.push('Tages'); }
-        if (stardock) { drmNames.push('Stardock Account Required'); }
-        if (rockstar) { drmNames.push('Rockstar Social Club'); }
+        if (gfwl) { drmNames.push("Games for Windows Live"); }
+        if (uplay) { drmNames.push("Ubisoft Uplay"); }
+        if (securom) { drmNames.push("SecuROM"); }
+        if (tages) { drmNames.push("Tages"); }
+        if (stardock) { drmNames.push("Stardock Account Required"); }
+        if (rockstar) { drmNames.push("Rockstar Social Club"); }
         if (kalypso) { drmNames.push("Kalypso Launcher"); }
         if (denuvo) { drmNames.push("Denuvo Anti-tamper"); }
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -169,6 +169,12 @@ class StorePageClass {
     addDrmWarnings() {
         if (!SyncedStorage.get("showdrm")) { return; }
 
+        // Prevent false-positives
+        if (this.isAppPage() && (
+               this.appid === 21690    // Resident Evil 5, at Capcom's request
+            || this.appid === 1157970  // Special K
+        )) { return; }
+
         let text = "";
         for (let node of document.querySelectorAll(".game_area_sys_req, #game_area_legal, .game_details, .DRM_notice")) {
             text += node.textContent.toLowerCase();
@@ -228,19 +234,16 @@ class StorePageClass {
         if (origin) { drmNames.push("EA Origin"); }
         if (xbox) { drmNames.push("Microsoft Xbox Live"); }
 
-        let drm = false;
         let drmString;
         let regex = /\b(drm|account|steam)\b/i;
         if (drmNames.length > 0) {
             drmString = `(${drmNames.join(", ")})`;
-            drm = true;
         } else { // Detect other DRM
             if (this.isAppPage()) {
                 for (let node of document.querySelectorAll("#category_block > .DRM_notice")) {
                     let text = node.textContent;
                     if (text.match(regex)) {
                         drmString = text;
-                        drm = true;
                         break;
                     }
                 }
@@ -250,18 +253,11 @@ class StorePageClass {
                 let text = node.textContent + node.nextSibling.textContent;
                 if (text.match(regex)) {
                     drmString = text;
-                    drm = true;
                 }
             }
         }
 
-        // Prevent false-positives
-        if (this.isAppPage() && (
-               this.appid === 21690    // Resident Evil 5, at Capcom's request
-            || this.appid === 1157970  // Special K
-        )) { drm = false; }
-
-        if (drm) {
+        if (drmString) {
             let warnString;
             if (drmNames.length > 0) {
                 warnString = this.isAppPage() ? Localization.str.drm_third_party : Localization.str.drm_third_party_sub;


### PR DESCRIPTION
Resolves #361 by copying the text from a DRM notice that contains "DRM" or "...account (Supports Linking to Steam Account)" and placing it in the warning box. Ideally it should be made to extract the custom text provided by devs, but I feel it's too much work for what it's worth.
Also added EA Origin & Xbox Live detection.