### PR TITLE
Added error message check for user profiles

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -463,6 +463,10 @@ let ProfileActivityPageClass = (function(){
 let ProfileHomePageClass = (function(){
 
     function ProfileHomePageClass() {
+        // If there is an error message, like profile does not exists. 
+        if (document.querySelector("#message")) {
+            return;
+        }
         if (window.location.hash === "#as-success") {
             /* TODO This is a hack. It turns out, that clearOwn clears data, but immediately reloads them.
              *      That's why when we clear profile before going to API to store changes we don't get updated images


### PR DESCRIPTION
AS would produce a lot of errors, if a profile did not exist. This fixes that.

![image](https://user-images.githubusercontent.com/4411977/69382441-5d2cff80-0cb7-11ea-915b-85e2694e07a4.png)
