### PR TITLE
Improve "Show achievement stats on All Games page" option

### DIFF
--- a/js/background/background.js
+++ b/js/background/background.js
@@ -476,7 +476,7 @@ class SteamCommunity extends Api {
     }
 
     static stats({ "params": params, }) {
-        return SteamCommunity.getPage(`/my/stats/${params.appid}`);
+        return SteamCommunity.getPage(`/${params.profile}/stats/${params.appid}`);
     }
 
     static async getInventory(contextId) {

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -875,8 +875,8 @@ let Stats = (function() {
 
     let self = {};
 
-    self.getAchievementBar = function(appid) {
-        return Background.action("stats", { "appid": appid }).then(response => {
+    self.getAchievementBar = function(appid, profile) {
+        return Background.action("stats", { "appid": appid, "profile": profile }).then(response => {
             let dummy = HTMLParser.htmlToDOM(response);
             let achNode = dummy.querySelector("#topSummaryAchievements");
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2048,7 +2048,7 @@ class AppPageClass extends StorePageClass {
 
         HTML.afterEnd(details_block,"<div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
 
-        Stats.getAchievementBar(this.communityAppid).then(achieveBar => {
+        Stats.getAchievementBar(this.communityAppid, "my").then(achieveBar => {
             if (!achieveBar) {
                 console.warn("Failed to find achievement stats for appid", this.communityAppid);
                 return;


### PR DESCRIPTION
1. Make it so that this option will show achievements for the profile you're currently viewing, instead of only showing your achievements on the games you own.
2. Minor refactoring.