### PR TITLE
Improve "Show achievement stats on All Games page" option

### DIFF
--- a/js/background/background.js
+++ b/js/background/background.js
@@ -476,7 +476,7 @@ class SteamCommunity extends Api {
     }
 
     static stats({ "params": params, }) {
-        return SteamCommunity.getPage(`/my/stats/${params.appid}`);
+        return SteamCommunity.getPage(`${params.path}/stats/${params.appid}`);
     }
 
     static async getInventory(contextId) {

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -907,7 +907,6 @@ let Stats = (function() {
     };
 
     return self;
-
 })();
 
 let EnhancedSteam = (function() {

--- a/js/content/common.js
+++ b/js/content/common.js
@@ -875,8 +875,8 @@ let Stats = (function() {
 
     let self = {};
 
-    self.getAchievementBar = function(appid) {
-        return Background.action("stats", { "appid": appid }).then(response => {
+    self.getAchievementBar = function(path, appid) {
+        return Background.action("stats", { "path": path, "appid": appid }).then(response => {
             let dummy = HTMLParser.htmlToDOM(response);
             let achNode = dummy.querySelector("#topSummaryAchievements");
 

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1143,7 +1143,7 @@ let GamesPageClass = (function(){
         // Path of profile in view to retrieve achievement stats
         let path = window.location.pathname.replace("/games", "");
 
-        document.addEventListener("scroll", function(){
+        document.addEventListener("scroll", () => {
             if (scrollTimeout) { window.clearTimeout(scrollTimeout); }
             scrollTimeout = window.setTimeout(addAchievements, 500);
         });
@@ -1154,8 +1154,7 @@ let GamesPageClass = (function(){
             // Only show stats on the "All Games" tab
             let nodes = document.querySelectorAll(".gameListRow:not(.es_achievements_checked)");
             let hadNodesInView = false;
-            for (let i=0, len=nodes.length; i<len; i++) {
-                let node = nodes[i];
+            for (let node of nodes) {
 
                 if (!Viewport.isElementInViewport(node)) {
                     if (hadNodesInView) { break; }
@@ -1167,18 +1166,16 @@ let GamesPageClass = (function(){
                 let appid = GameId.getAppidWishlist(node.id);
                 node.classList.add("es_achievements_checked");
                 if (!node.innerHTML.match(/ico_stats\.png/)) { continue; }
-                if (!node.querySelector("h5.hours_played")) { continue; }
 
-                // Copy achievement stats to row
-                HTML.afterEnd(node.querySelector("h5"), "<div class='es_recentAchievements' id='es_app_" + appid + "'></div>");
+                let hoursNode = node.querySelector("h5.hours_played");
+                if (!hoursNode) { continue; }
+
+                HTML.afterEnd(hoursNode, `<div class="es_recentAchievements" id="es_app_${appid}"></div>`);
 
                 Stats.getAchievementBar(path, appid).then(achieveBar => {
-                    let node = document.querySelector("#es_app_" + appid);
+                    if (!achieveBar) { return; }
 
-                    if (!achieveBar) return;
-
-                    HTML.inner(node, achieveBar);
-
+                    HTML.inner(document.querySelector(`#es_app_${appid}`), achieveBar);
                 }, err => {
                     console.error(err);
                 });

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1092,10 +1092,8 @@ let GamesPageClass = (function(){
         if (!document.querySelector(".gameListRow")) {
             return;
         }
-
-        let page = window.location.href.match(/(\/(?:id|profiles)\/.+\/)games\/?(\?tab=all)?/);
-
-        if (page[2]) {
+        // Only show stats on the "All Games" tab
+        if (window.location.search.includes("?tab=all")) {
             this.computeStats();
             this.handleCommonGames();
             this.addGamelistAchievements();
@@ -1151,7 +1149,6 @@ let GamesPageClass = (function(){
         addAchievements();
 
         function addAchievements() {
-            // Only show stats on the "All Games" tab
             let nodes = document.querySelectorAll(".gameListRow:not(.es_achievements_checked)");
             let hadNodesInView = false;
             for (let node of nodes) {
@@ -1188,11 +1185,10 @@ let GamesPageClass = (function(){
     async function loadCommonGames() {
         if (_commonGames != null) { return; }
 
-        let url = window.location.href;
-        let commonUrl = url + (url.indexOf( '?' ) != -1 ? '&' : '?' ) + 'games_in_common=1';
+        let commonUrl = `${window.location.href}&games_in_common=1`;
         let data = await RequestData.getHttp(commonUrl);
 
-        let games = HTMLParser.getVariableFromText(data, "rgGames", "array");;
+        let games = HTMLParser.getVariableFromText(data, "rgGames", "array");
         _commonGames = new Set();
         for (let game of games) {
             _commonGames.add(parseInt(game.appid));

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1098,7 +1098,7 @@ let GamesPageClass = (function(){
         if (page[2]) {
             this.computeStats();
             this.handleCommonGames();
-            this.addGamelistAchievements(page[1]);
+            this.addGamelistAchievements();
         }
     }
 
@@ -1137,12 +1137,11 @@ let GamesPageClass = (function(){
 
     let scrollTimeout = null;
 
-    GamesPageClass.prototype.addGamelistAchievements = function(userProfileLink) {
+    GamesPageClass.prototype.addGamelistAchievements = function() {
         if (!SyncedStorage.get("showallachievements")) { return; }
 
-        let node = document.querySelector(".profile_small_header_texture a");
-        if (!node) { return; }
-        let statsLink = "https://steamcommunity.com/" + userProfileLink + "stats/";
+        // Path of profile in view to retrieve achievement stats
+        let path = window.location.pathname.replace("/games", "");
 
         document.addEventListener("scroll", function(){
             if (scrollTimeout) { window.clearTimeout(scrollTimeout); }
@@ -1173,7 +1172,7 @@ let GamesPageClass = (function(){
                 // Copy achievement stats to row
                 HTML.afterEnd(node.querySelector("h5"), "<div class='es_recentAchievements' id='es_app_" + appid + "'></div>");
 
-                Stats.getAchievementBar(appid).then(achieveBar => {
+                Stats.getAchievementBar(path, appid).then(achieveBar => {
                     let node = document.querySelector("#es_app_" + appid);
 
                     if (!achieveBar) return;

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1088,6 +1088,10 @@ let GroupHomePageClass = (function(){
 let GamesPageClass = (function(){
 
     function GamesPageClass() {
+        // Prevent errors if "Game Details" is private
+        if (!document.querySelector(".gameListRow")) {
+            return;
+        }
 
         let page = window.location.href.match(/(\/(?:id|profiles)\/.+\/)games\/?(\?tab=all)?/);
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2048,7 +2048,7 @@ class AppPageClass extends StorePageClass {
 
         HTML.afterEnd(details_block,"<div id='es_ach_stats' style='margin-bottom: 9px; margin-top: -16px; float: right;'></div>");
 
-        Stats.getAchievementBar(this.communityAppid).then(achieveBar => {
+        Stats.getAchievementBar("/my", this.communityAppid).then(achieveBar => {
             if (!achieveBar) {
                 console.warn("Failed to find achievement stats for appid", this.communityAppid);
                 return;


### PR DESCRIPTION
1. Make it so that this option will show achievements for the profile you're currently viewing, instead of only showing your achievements on the games you own.
2. Minor refactoring.