### PR TITLE
Restore AS's filter option on "All Games" page

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2897,9 +2897,9 @@ input[type=checkbox].es_dlc_selection:checked + label {
   overflow: hidden;
 }
 
-.esi-hide-common .esi-common {
-  display: none !important;
-}
+.esi-hide-common .esi-common { display: none; }
+.esi-hide-notcommon .esi-notcommon { display: none; }
+
 
 .esi-stream {
   position: relative;

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2897,9 +2897,15 @@ input[type=checkbox].es_dlc_selection:checked + label {
   overflow: hidden;
 }
 
-.esi-hide-common .esi-common { display: none; }
-.esi-hide-notcommon .esi-notcommon { display: none; }
-
+/* hide Steam's option on "All Games" page */
+input[id='show_common_games'],
+label[for='show_common_games'] {
+  display: none;
+}
+.esi-hide-common .esi-common,
+.esi-hide-notcommon .esi-notcommon { 
+  display: none !important;
+}
 
 .esi-stream {
   position: relative;

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2898,8 +2898,8 @@ input[type=checkbox].es_dlc_selection:checked + label {
 }
 
 /* hide Steam's option on "All Games" page */
-input[id='show_common_games'],
-label[for='show_common_games'] {
+input[id="show_common_games"],
+label[for="show_common_games"] {
   display: none;
 }
 .esi-hide-common .esi-common,

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1194,37 +1194,29 @@ let GamesPageClass = (function(){
     }
 
     GamesPageClass.prototype.handleCommonGames = function() {
-        if (!User.isSignedIn) { return;}
+        if (!User.isSignedIn) { return; }
 
         let label = document.querySelector("label[for='show_common_games']");
         if (!label) { return; }
 
-        function createCheckbox(id, string) {
-            let checkbox = document.createElement("input");
-            checkbox.type = "checkbox";
-            checkbox.id = id;
+        HTML.afterEnd(label,
+            `<label for="es_gl_show_common_games"><input type="checkbox" id="es_gl_show_common_games">${Localization.str.common_label}</label>
+            <label for="es_gl_show_notcommon_games"><input type="checkbox" id="es_gl_show_notcommon_games">${Localization.str.notcommon_label}</label>`);
 
-            let label = document.createElement("label");
-            label.append(checkbox, string);
-
-            return checkbox;
-        }
-
-        let commonCheckbox = createCheckbox("es_gl_show_common_games", Localization.str.common_label);
-        let notCommonCheckbox = createCheckbox("es_gl_show_notcommon_games", Localization.str.notcommon_label);
-
-        label.insertAdjacentElement("afterend", notCommonCheckbox.parentNode);
-        label.insertAdjacentElement("afterend", commonCheckbox.parentNode);
+        let commonCheckbox = document.getElementById("es_gl_show_common_games");
+        let notCommonCheckbox = document.getElementById("es_gl_show_notcommon_games");
+        let rows = document.getElementById("games_list_rows");
 
         commonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
-            document.querySelector("#games_list_rows").classList.toggle("esi-hide-notcommon", e.target.checked);
+            rows.classList.toggle("esi-hide-notcommon", e.target.checked);
             ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
         });
 
         notCommonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
-            document.querySelector("#games_list_rows").classList.toggle("esi-hide-common", e.target.checked);
+            rows.classList.toggle("esi-hide-common", e.target.checked);
+            ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
         });
     };
 

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1220,12 +1220,12 @@ let GamesPageClass = (function(){
         commonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
             document.querySelector("#games_list_rows").classList.toggle("esi-hide-notcommon", e.target.checked);
+            ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
         });
 
         notCommonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
             document.querySelector("#games_list_rows").classList.toggle("esi-hide-common", e.target.checked);
-            ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
         });
     };
 

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1187,6 +1187,8 @@ let GamesPageClass = (function(){
 
             if (_commonGames.has(appid)) {
                 node.classList.add("esi-common");
+            } else {
+                node.classList.add("esi-notcommon");
             }
         }
     }
@@ -1209,8 +1211,16 @@ let GamesPageClass = (function(){
             return checkboxEl;
         }
 
+        let commonCheckbox = createCheckox("es_gl_show_common_games", Localization.str.common_label);
         let notCommonCheckbox = createCheckox("es_gl_show_notcommon_games", Localization.str.notcommon_label);
+
         label.insertAdjacentElement("afterend", notCommonCheckbox.parentNode);
+        label.insertAdjacentElement("afterend", commonCheckbox.parentNode);
+
+        commonCheckbox.addEventListener("change", async function(e) {
+            await loadCommonGames();
+            document.querySelector("#games_list_rows").classList.toggle("esi-hide-notcommon", e.target.checked);
+        });
 
         notCommonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1199,20 +1199,19 @@ let GamesPageClass = (function(){
         let label = document.querySelector("label[for='show_common_games']");
         if (!label) { return; }
 
-        function createCheckox(id, string) {
-            let checkboxEl = document.createElement("input");
-            checkboxEl.type = "checkbox";
-            checkboxEl.id = id;
+        function createCheckbox(id, string) {
+            let checkbox = document.createElement("input");
+            checkbox.type = "checkbox";
+            checkbox.id = id;
 
-            let uncommonLabel = document.createElement("label");
-            uncommonLabel.append(checkboxEl);
-            uncommonLabel.append(document.createTextNode(string));
+            let label = document.createElement("label");
+            label.append(checkbox, string);
 
-            return checkboxEl;
+            return checkbox;
         }
 
-        let commonCheckbox = createCheckox("es_gl_show_common_games", Localization.str.common_label);
-        let notCommonCheckbox = createCheckox("es_gl_show_notcommon_games", Localization.str.notcommon_label);
+        let commonCheckbox = createCheckbox("es_gl_show_common_games", Localization.str.common_label);
+        let notCommonCheckbox = createCheckbox("es_gl_show_notcommon_games", Localization.str.notcommon_label);
 
         label.insertAdjacentElement("afterend", notCommonCheckbox.parentNode);
         label.insertAdjacentElement("afterend", commonCheckbox.parentNode);


### PR DESCRIPTION
If getting images to load is as simple as https://github.com/tfedor/AugmentedSteam/commit/01e9d69bab059fdfe92eab48ff8cd64c2fecb029 , I think we can consider hiding Steam's option instead, since as mentioned in https://github.com/tfedor/AugmentedSteam/issues/681#issuecomment-564059216 our option does have the advantage of not refreshing the page.

Additionally, https://github.com/tfedor/AugmentedSteam/commit/01e9d69bab059fdfe92eab48ff8cd64c2fecb029 should be applied when hiding uncommon games instead, because that's when games further down with unloaded images potentially get shown.