### PR TITLE
Improve fix for franchise row search links

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1634,7 +1634,7 @@ class AppPageClass extends StorePageClass {
     replaceDevPubLinks() {
         if (!this.isAppPage()) { return; }
 
-        document.querySelectorAll("#game_highlights .dev_row a,.details_block .dev_row:not(:last-of-type) a").forEach((linkNode, i) => {
+        document.querySelectorAll("#game_highlights .dev_row a,.details_block .dev_row:not(:nth-of-type(3)) a").forEach((linkNode, i) => {
             let homepageLink = new URL(linkNode.href);
             if (homepageLink.pathname === "/search/") return;
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -1645,7 +1645,7 @@ class AppPageClass extends StorePageClass {
         });
 
         for (let moreBtn of document.querySelectorAll(".dev_row > .more_btn")) {
-            if (moreBtn) { moreBtn.remove(); }
+            moreBtn.remove();
         }
 
         ExtensionLayer.runInPageContext(() => CollapseLongStrings(".dev_row .summary.column"));


### PR DESCRIPTION
Fix https://github.com/tfedor/AugmentedSteam/issues/674#issuecomment-560113211
Apps don't necessarily have a franchise row, so the last row could be a publisher row.

Also removed unnecessary check as mentioned in https://github.com/tfedor/AugmentedSteam/pull/655#discussion_r349700371