### PR TITLE
Add pagination on "all games" profile page. Closes #622

### DIFF
--- a/css/sliwipi-common.css
+++ b/css/sliwipi-common.css
@@ -1,0 +1,56 @@
+/*
+ Copyright 2017 Yan Li
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+.sliwipi-pagination {
+  text-align: center;
+  margin: 15px 0;
+}
+.sliwipi-pagination > * {
+  display: inline-block;
+  height: 24px;
+  min-width: 44px;
+  margin-left: 3px;
+  padding-left: 5px !important;
+  padding-right: 5px !important;
+}
+.sliwipi-pulldown {
+  display: inline-block;
+}
+.sliwipi-sorting-options {
+  display: inline-block;
+  float: right;
+}
+.sliwipi-dropdown-label {
+  font-weight: bold;
+  text-decoration: underline;
+}
+#gameslist_controls > .gray_bevel.for_text_input {
+  margin-left: 5px;
+}
+
+.library-owned-list-pagination {
+  text-align: center;
+  margin: 15px 0;
+}
+
+.library-owned-list-pagination > * {
+  display: inline-block;
+  height: 24px;
+  min-width: 44px;
+  margin-left: 3px;
+  padding-left: 5px !important;
+  padding-right: 5px !important;
+}

--- a/js/content/community.js
+++ b/js/content/community.js
@@ -1198,14 +1198,24 @@ let GamesPageClass = (function(){
 
         commonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
-            rows.classList.toggle("esi-hide-notcommon", e.target.checked);
-            ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
+            if (!SyncedStorage.get("library_pagination")) {
+              rows.classList.toggle("esi-hide-notcommon", e.target.checked);
+              ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
+            } else {
+                var event = new CustomEvent('update', { 'detail': JSON.stringify({ 'commonGames': [..._commonGames],'common': e.target.checked, 'notcommon': null })});
+                e.target.parentElement.parentElement.dispatchEvent(event);
+	    }
         });
 
         notCommonCheckbox.addEventListener("change", async function(e) {
             await loadCommonGames();
-            rows.classList.toggle("esi-hide-common", e.target.checked);
-            ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
+            if (!SyncedStorage.get("library_pagination")) {
+                rows.classList.toggle("esi-hide-common", e.target.checked);
+                ExtensionLayer.runInPageContext(() => CScrollOffsetWatcher.ForceRecalc());
+            } else {
+                var event = new CustomEvent('update', { 'detail': JSON.stringify({ 'commonGames': [..._commonGames],'common': null, 'notcommon': e.target.checked })});
+                e.target.parentElement.parentElement.dispatchEvent(event);
+	    }
         });
     };
 

--- a/js/core.js
+++ b/js/core.js
@@ -677,6 +677,9 @@ SyncedStorage.defaults = {
     'profile_custom_link': [
         { 'enabled': true, 'name': "Google", 'url': "google.com/search?q=[ID]", 'icon': "www.google.com/images/branding/product/ico/googleg_lodp.ico", },
     ],
+    'library_pagination': true,
+    'library_rows_per_page': 15,
+    'library_default_sort': "name",
     'group_steamgifts': true,
     'steamcardexchange': true,
     'purchase_dates': true,

--- a/js/sliwipi/library-performance-injectable.js
+++ b/js/sliwipi/library-performance-injectable.js
@@ -1,0 +1,404 @@
+/*
+ Copyright 2017 Yan Li
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * @property {function} String.prototype.escapeHTML
+ * @property {string} HTMLElement.prototype.dataset.img
+ */
+/**
+ * @typedef {object} IGameInfo
+ * @property {string} name
+ * @property {string} appid
+ * @property {string|null} hours_forever
+ * @property {string|null} hours_message
+ * @property {string|null} stats_links
+ * @property {string|null} stats_button
+ * @property {number} hours
+ * @property {object} client_summary
+ * @property {number} installedSize
+ * @property {boolean} status
+ * @property {boolean} played
+ * @property {object} availStatLinks
+ * @property {string|null} item_background
+ * @property {string} logo
+ * @property {string} persona_name
+ * @property {string} profile_link
+ * @property {string} name_encoded
+ * @property {string} name_escaped
+ * @property {string} info_link
+ */
+/**
+ * @typedef {object} PaginationPluginParams
+ * @property {number} currentPage
+ * @property {Array} elements
+ * @property {number} perPage
+ * @property {function} change
+ */
+/**
+ * @typedef {object} ITemplate
+ * @property {string} template
+ * @property {RegExp} pattern
+ */
+
+/**
+ * @method
+ * @name ITemplate#evaluate
+ * @param {object}
+ * @returns {string}
+ */
+
+/**
+ * @typedef {object} ISliwipi
+ * @property {number} perPage
+ * @property {object} fileSizeMultipliers
+ * @property {string} html
+ */
+
+/** @var {object[]} rgGames */
+/** @var {ISliwipi} SLIWIPI */
+/** @var {Template} gameLinksPopupTemplate */
+/** @var {Template} gameStatsPopupTemplate */
+/** @var {Template} gameTemplate */
+/** @var {Template} gameStatsAchievementsTemplate */
+/** @var {Template} gameStatsLeaderboardTemplate */
+/** @var {Template} gameStatsGlobalAchievementsTemplate */
+/** @var {Template} gameStatsGlobalLeaderboardsTemplate */
+/** @var {Template} gameHoursForeverTemplate */
+/** @var {Template} gameStatsTemplate */
+/** @var {Template} gameStatsUserTemplate */
+/** @var {string} personaName */
+/** @var {string} profileLink */
+/** @var {function} UpdateGameInfoFromSummary */
+/** @var {boolean} SLIWIPI_BUILD_GAME_ROW_PATCHED */
+
+(async function () {
+
+  let _common = false;
+  let _notcommon = false;
+  let _commonGames = null;
+
+  document.getElementById('gameslist_controls').addEventListener('update', function(e){
+    let detail = JSON.parse(e.detail);
+    if (detail.common != null)
+      _common = detail.common;
+    if (detail.notcommon != null)
+      _notcommon = detail.notcommon;
+    _commonGames = new Set(detail.commonGames);
+    predebounceFilterApps();
+  })
+
+  /** @property {ISliwipi|null} window.SLIWIPI */
+  function debounce(delay, cb) {
+    let timer;
+    return function() {
+      if(timer)
+        clearTimeout(timer);
+      timer = setTimeout(cb, delay);
+    };
+  }
+//  (window.SLIWIPI || window).debounce = debounce;
+
+  /** @property {ISliwipi|null} window.SLIWIPI */
+  function isInViewport(el) {
+    const rect = el.getBoundingClientRect();
+    return rect.top >= -300 &&
+      rect.left >= -300 &&
+      rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) + 300 &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth) + 300;
+  }
+//  (window.SLIWIPI || window).isInViewport = isInViewport;
+
+  function generatePagination(currentPage, elements, perPage) {
+    let html = '';
+    let totalPages = Math.ceil(elements.length / perPage);
+    if (totalPages <= 1)
+      return '';
+    if (currentPage > 1)
+      html += '<button type="button" class="pagination-navprev btnv6_blue_hoverfade" data-locale-text="pagination_button_prev">&lt; prev</button>';
+    if(currentPage !== 1)
+      html += '<button type="button" class="btnv6_blue_hoverfade">1</button>';
+    else
+      html += '<span>1</span>';
+    if(currentPage === 5)
+      html += '<button type="button" class="btnv6_blue_hoverfade">2</button>';
+    if (currentPage > 2) {
+      if(currentPage > 5)
+        html += '<span>...</span>';
+      if (currentPage > 3)
+        html += '<button type="button" class="btnv6_blue_hoverfade">' + (currentPage - 2) + '</button>';
+      html += '<button type="button" class="btnv6_blue_hoverfade">' + (currentPage - 1) + '</button>';
+    }
+    if (currentPage !== 1 && currentPage !== totalPages)
+      html += '<span>' + currentPage + '</span>';
+    if (currentPage < totalPages - 1) {
+      html += '<button type="button" class="btnv6_blue_hoverfade">' + (currentPage + 1) + '</button>';
+      if (currentPage < totalPages - 2)
+        html += '<button type="button" class="btnv6_blue_hoverfade">' + (currentPage + 2) + '</button>';
+      if(currentPage < totalPages - 4)
+        html += '<span>...</span>';
+    }
+    if(currentPage === totalPages - 4)
+      html += '<button type="button" class="btnv6_blue_hoverfade">' + (totalPages - 1) + '</button>';
+    if(currentPage !== totalPages)
+      html += '<button type="button" class="btnv6_blue_hoverfade">' + totalPages + '</button>';
+    else
+      html += '<span>' + totalPages + '</span>';
+    if (currentPage < totalPages)
+      html += '<button type="button" class="pagination-navnext btnv6_blue_hoverfade" data-locale-text="pagination_button_next">next &gt;</button>';
+    return html;
+  }
+
+
+
+  /**
+   * @name PaginationPluginParams
+   * @property {number} currentPage
+   * @property {object[]} elements
+   * @property {number} perPage Amount of items displayed per page
+   */
+  /**
+   * @param {PaginationPluginParams} obj
+   */
+  function pagination(elements,obj) {
+    let html = generatePagination(obj.currentPage, obj.elements, obj.perPage);    
+    let clickListener = function (event){
+        let inner = event.target;
+        if (inner.tagName != "BUTTON") return;
+        let newPage = inner.textContent;
+        if (inner.classList.contains('pagination-navprev'))
+          obj.currentPage--;
+        else if (inner.classList.contains('pagination-navnext'))
+          obj.currentPage++;
+        else
+          obj.currentPage = +newPage;
+        let html = generatePagination(obj.currentPage, obj.elements, obj.perPage);
+        for (let elementNumber=0; elementNumber < elements.length; elementNumber++){
+          elements[elementNumber].innerHTML = html;
+        }
+        obj.change(obj.currentPage);
+
+    }
+
+    for (let elementNumber=0; elementNumber < elements.length; elementNumber++){
+      elements[elementNumber].removeEventListener("click",clickListener);
+      elements[elementNumber].addEventListener("click",clickListener);
+      elements[elementNumber].innerHTML = html;
+    }
+  };
+//  window.pagination = pagination;
+
+  if(!window.SLIWIPI_BUILD_GAME_ROW_PATCHED)
+    return;
+  for(let game of window.rgGames) {
+    BuildGameRow(game);
+  }
+
+  document.querySelector('#games_list_rows').innerHTML = '<div class="library-owned-list-pagination"></div><div class="sliwipi-actual-list"></div><div class="library-owned-list-pagination"></div>';
+
+  let hideUnnecessaryOptionsImg1 = document.querySelector('#global_actions > a > img');
+  let hideUnnecessaryOptionsImg2 = document.querySelector('.profile_small_header_avatar > .playerAvatar > img');
+  let hideUnnecessaryOptions = !hideUnnecessaryOptionsImg1 || !hideUnnecessaryOptionsImg2 || hideUnnecessaryOptionsImg1.getAttribute('src') !== hideUnnecessaryOptionsImg2.getAttribute('src').replace('_medium', '');
+
+  const originalData = JSON.parse(JSON.stringify(rgGames)).map(/**IGameInfo*/row => {
+    row.hours = row.hours_forever ? parseFloat(row.hours_forever.replace(/,/g, '')) : 0;
+    if(!row.client_summary) {
+      row.client_summary = {
+        localContentSize: '0 B'
+      };
+    }
+    let splitSize = row.client_summary.localContentSize.split(' ');
+    let size = parseFloat(splitSize[0]) * SLIWIPI.fileSizeMultipliers[splitSize[1]];
+    if (isNaN(size))
+      size = 0;
+    row.installedSize = size;
+    row.status = row.installedSize > 0;
+
+    row.played = row.hours > 0;
+
+    return row;
+  });
+  let filteredData = originalData;
+
+  SLIWIPI.html = decodeURIComponent(SLIWIPI.html);
+
+  let gameslistSortOptions = document.querySelector('#gameslist_sort_options');
+  gameslistSortOptions.id = '';
+  gameslistSortOptions.innerHTML = SLIWIPI.html;
+
+  let br = document.createElement('br');
+  let gamesInCommonCheckbox = document.querySelector('#gameslist_controls > .gray_bevel.for_text_input').nextElementSibling;
+  gamesInCommonCheckbox.parentNode.insertBefore(br, gamesInCommonCheckbox);
+
+  if(hideUnnecessaryOptions) {
+    document.querySelectorAll('[data-data="installedSize"],[data-data$="installed"]').forEach(v => {
+      v.parentNode.removeChild(v);
+    });
+  }
+
+  let sortingBy = SLIWIPI.sortBy;
+  let filterBy = 'all';
+
+  function changeDropdownLabel(target) {
+    let label = target.parentNode.parentNode.parentNode.querySelector('.sliwipi-dropdown-label');
+    label.textContent = target.textContent;
+    label.dataset.localeText = target.dataset.localeText;
+  }
+  changeDropdownLabel(document.querySelector(`[data-data="${sortingBy}"]`));
+  let sortmenu = document.querySelector('#sliwipi-sort-by-dropdown').getElementsByTagName('a');
+  for (let menuindex=0;menuindex<sortmenu.length;menuindex++){
+    sortmenu[menuindex].addEventListener('click', function(e) {
+      changeDropdownLabel(this);
+      e.preventDefault();
+
+      sortingBy = this.dataset.data;
+      predebounceFilterApps();
+    });
+  }
+
+  let filtermenu = document.querySelector('#sliwipi-filter-by-pulldown').getElementsByTagName('a');
+  for (let menuindex=0;menuindex<filtermenu.length;menuindex++){
+    filtermenu[menuindex].addEventListener('click', function(e) {
+      changeDropdownLabel(this);
+      e.preventDefault();
+
+      filterBy = this.dataset.data;
+      predebounceFilterApps();
+    });
+  }
+
+  let filterInput = document.querySelector('#gameFilter');
+
+  let popupsContainer = document.createElement('div');
+  document.body.appendChild(popupsContainer);
+
+  let listContainer = document.querySelector('.sliwipi-actual-list');
+
+  let currentPage;
+  SLIWIPI.pageNum = 1;
+
+  const FILTER_OPTIONS = {
+    all: 'all',
+    installed: 'installed',
+    noninstalled: '-installed',
+    played: 'played',
+    nonplayed: '-played'
+  };
+  const SORTING_OPTIONS = {
+    name: 'name',
+    playtime: 'playtime',
+    installedSize: 'installedSize'
+  };
+
+  function filterOut() {
+    let sortingFunction, filteringFunction;
+    let name = filterInput.value.trim().toLowerCase();
+    switch(sortingBy) {
+      case SORTING_OPTIONS.name:
+        sortingFunction = firstBy('name', { ignoreCase: true });
+        break;
+      case SORTING_OPTIONS.playtime:
+        sortingFunction = firstBy('hours', { direction: -1 }).thenBy('name', { ignoreCase: true });
+        break;
+      case SORTING_OPTIONS.installedSize:
+        sortingFunction = firstBy('installedSize', { direction: -1 }).thenBy('name', { ignoreCase: true });
+        break;
+    }
+    switch(filterBy) {
+      case FILTER_OPTIONS.all:
+        filteringFunction = v => v.name.toLowerCase().includes(name);
+        break;
+      case FILTER_OPTIONS.installed:
+        filteringFunction = v => v.name.toLowerCase().includes(name) && v.status;
+        break;
+      case FILTER_OPTIONS.noninstalled:
+        filteringFunction = v => v.name.toLowerCase().includes(name) && !v.status;
+        break;
+      case FILTER_OPTIONS.played:
+        filteringFunction = v => v.name.toLowerCase().includes(name) && v.played;
+        break;
+      case FILTER_OPTIONS.nonplayed:
+        filteringFunction = v => v.name.toLowerCase().includes(name) && !v.played;
+        break;
+    }
+    let esFilteringFunction  = v => filteringFunction(v) && (_common?_commonGames.has(v.appid):true) && (_notcommon?!_commonGames.has(v.appid):true);
+    filteredData = originalData.filter(esFilteringFunction).sort(sortingFunction);
+    window.filteredData = filteredData;
+  }
+
+  function reapplyPagination(num = 1) {
+    if(!pagination) {
+      setTimeout(reapplyPagination.bind(null, num), 500);
+      return;
+    }
+    pagination(document.getElementsByClassName('library-owned-list-pagination'),{
+      currentPage: num,
+      elements: filteredData,
+      perPage: SLIWIPI.perPage,
+      change: changePage,
+    });
+  }
+
+  SLIWIPI.reapplyPagination = reapplyPagination;
+
+  function predebounceFilterApps() {
+    filterOut();
+    changePage(1);
+    reapplyPagination();
+  }
+
+  window.filterApps = debounce(500, predebounceFilterApps);
+
+  function changePage(newPage) {
+    SLIWIPI.pageNum = newPage;
+    let start = SLIWIPI.perPage * (newPage - 1);
+    currentPage = filteredData.slice(start, start + SLIWIPI.perPage);
+    regenerateList();
+  }
+
+  function loadImagesInViewport() {
+    const images = document.querySelectorAll('.gameListRowLogo img[id^="delayedimage_"]');
+    for(const image of images) {
+      if(isInViewport(image)) {
+        image.src = image.parentNode.parentNode.parentNode.dataset.img || image.parentNode.parentNode.parentNode.parentNode.dataset.img;
+        image.removeAttribute('id');
+      }
+    }
+  }
+
+  document.addEventListener('scroll', debounce(50, loadImagesInViewport), { passive: true });
+
+  function regenerateList() {
+    let popupsHtml = '';
+    let listHtml = '';
+    for (let info of currentPage) {
+      popupsHtml += `<div class="popup_block2" id="links_dropdown_${info.appid}" style="display: none;">${gameLinksPopupTemplate.evaluate(info)}</div>`;
+
+      if (info.stats_links)
+        popupsHtml += `<div class="popup_block2" id="stats_dropdown_${info.appid}" style="display: none;">${gameStatsPopupTemplate.evaluate(info)}</div>`;
+
+      let html = gameTemplate.evaluate(info);
+
+      listHtml += `<div class="gameListRow ${info.item_background || ''}" id="game_${info.appid}" data-img="${info.logo}">${html}</div>`;
+    }
+
+    popupsContainer.innerHTML = popupsHtml;
+    listContainer.innerHTML = listHtml;
+
+    loadImagesInViewport();
+  }
+
+  predebounceFilterApps();
+})();

--- a/js/sliwipi/library-performance.js
+++ b/js/sliwipi/library-performance.js
@@ -1,0 +1,146 @@
+/*
+ Copyright 2017 Yan Li
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/** @var {object} $ */
+
+(async function () {
+  const FILE_SIZE_MULTIPLIER = {
+    B:   Math.pow(1024, 0),
+    KiB: Math.pow(1024, 1),
+    MiB: Math.pow(1024, 2),
+    GiB: Math.pow(1024, 3),
+    TiB: Math.pow(1024, 4),
+    PiB: Math.pow(1024, 5),
+    EiB: Math.pow(1024, 6),
+    ZiB: Math.pow(1024, 7),
+    YiB: Math.pow(1024, 8)
+  };
+
+
+  await SyncedStorage.init().catch(err => console.error(err));
+  await Localization.init().catch(err => console.error(err));
+
+  let library = {
+      "perPage": SyncedStorage.get('library_rows_per_page'),
+      "enabled": SyncedStorage.get('library_pagination'),
+      "sortBy": SyncedStorage.get('library_default_sort')
+    }
+  if (!library.enabled)
+    return;
+
+  let s = document.createElement('script');
+  s.innerHTML = `(function() {
+  Object.defineProperty(window, 'rgGames', {
+    configurable: true,
+    get() {
+      return [];
+    },
+    set(newValue) {
+      window.SLIWIPI_rgGames = newValue;
+    }
+  });
+
+  function onReady() {
+    let str = window.BuildGameRow.toString().split('\\n');
+
+    function comment(line) {
+      str[line] = '//' + str[line];
+    }
+
+    if (str.length !== 111)
+      return;
+
+    /* I think including the actual code from the page with slight modifications
+     would be illegal?.. So this array contains the numbers of lines in the original
+     function that should be commented out. */
+    let lines = [
+      69, 70, 71, 72, 73, 74,
+      81, 82, 83, 84,
+      92, 93, 94, 95,
+      98,
+      100, 101, 102, 103, 104, 105,
+      107, 108, 109
+    ];
+
+    for (let line of lines) {
+      comment(line);
+    }
+
+    let s = document.createElement('script');
+    s.innerHTML = str.join('\\n');
+    document.head.appendChild(s);
+    s.parentNode.removeChild(s);
+
+    window.SLIWIPI_BUILD_GAME_ROW_PATCHED = true;
+
+    delete window.rgGames;
+    window.rgGames = window.SLIWIPI_rgGames;
+    delete window.SLIWIPI_rgGames;
+  }
+
+  document.addEventListener('DOMContentLoaded', onReady);
+})();`
+  //s.src = chrome.extension.getURL('/js/BuildGameRow-injectable.js');
+  document.documentElement.appendChild(s);
+  s.parentNode.removeChild(s);
+
+  async function onReady() {
+
+    let link1 = document.createElement('link');
+    link1.setAttribute('rel', 'stylesheet');
+    link1.setAttribute('href', chrome.extension.getURL('/css/sliwipi-common.css'));
+    document.head.appendChild(link1);
+
+    let html = await (await fetch(chrome.extension.getURL('library.html'))).text();
+    let parser = new DOMParser();
+    let doc = parser.parseFromString("<html><body>"+html+"</body></html>", "text/html");
+    let nodes = doc.querySelectorAll("[data-locale-text]");
+    for (let node of nodes) {
+      let translation = Localization.getString(node.dataset.localeText);
+      if (translation) {
+        node.textContent = translation;
+      } else {
+        console.warn(`Missing translation ${node.dataset.localeText}`);
+      }
+    }
+    html = doc.body.innerHTML;
+
+    let s = document.createElement('script');
+    s.innerHTML = `window.SLIWIPI = { 
+      perPage: ${library.perPage},
+      fileSizeMultipliers: ${JSON.stringify(FILE_SIZE_MULTIPLIER)},
+      sortBy: ${JSON.stringify(library.sortBy)},
+      html: \`${encodeURIComponent(html)}\`
+    };`;
+    document.body.appendChild(s);
+    s.parentNode.removeChild(s);
+
+    s = document.createElement('script');
+    s.innerHTML = await (await fetch(chrome.extension.getURL('/js/sliwipi/thenBy.js'))).text();
+    document.body.appendChild(s);
+    s.parentNode.removeChild(s);
+
+    s = document.createElement('script');
+    s.innerHTML = await (await fetch(chrome.extension.getURL('/js/sliwipi/library-performance-injectable.js'))).text();
+    document.body.appendChild(s);
+    s.parentNode.removeChild(s);
+  }
+
+  if(document.readyState === 'interactive' || document.readyState === 'complete')
+    onReady();
+  else
+    document.addEventListener('DOMContentLoaded', onReady);
+})();

--- a/js/sliwipi/thenBy.js
+++ b/js/sliwipi/thenBy.js
@@ -1,0 +1,53 @@
+/***
+ Copyright 2013 Teun Duynstee
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+var firstBy = (function() {
+
+  function identity(v){return v;}
+
+  function ignoreCase(v){return typeof(v)==="string" ? v.toLowerCase() : v;}
+
+  function makeCompareFunction(f, opt){
+    opt = typeof(opt)==="number" ? {direction:opt} : opt||{};
+    if(typeof(f)!="function"){
+      var prop = f;
+      // make unary function
+      f = function(v1){return !!v1[prop] ? v1[prop] : "";}
+    }
+    if(f.length === 1) {
+      // f is a unary function mapping a single item to its sort score
+      var uf = f;
+      var preprocess = opt.ignoreCase?ignoreCase:identity;
+      f = function(v1,v2) {return preprocess(uf(v1)) < preprocess(uf(v2)) ? -1 : preprocess(uf(v1)) > preprocess(uf(v2)) ? 1 : 0;}
+    }
+    if(opt.direction === -1) return function(v1,v2){return -f(v1,v2)};
+    return f;
+  }
+
+  /* adds a secondary compare function to the target function (`this` context)
+   which is applied in case the first one returns 0 (equal)
+   returns a new compare function, which has a `thenBy` method as well */
+  function tb(func, opt) {
+    var x = typeof(this) == "function" ? this : false;
+    var y = makeCompareFunction(func, opt);
+    var f = x ? function(a, b) {
+      return x(a,b) || y(a,b);
+    }
+      : y;
+    f.thenBy = tb;
+    return f;
+  }
+  return tb;
+})();

--- a/library.html
+++ b/library.html
@@ -1,0 +1,49 @@
+<!--
+ Copyright 2017 Yan Li
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<div class="sliwipi-sorting-options">
+  <div
+    id="sliwipi-sort-by-pulldown" class="pulldown global_action_link sliwipi-pulldown"
+    onmouseover="ShowMenu(this, 'sliwipi-sort-by-dropdown', 'right', 'bottom', true)"
+    onmouseout="HideMenu(this, 'sliwipi-sort-by-dropdown')"
+  >
+    <span data-locale-text="sort_by">Sort by</span>
+    <span class="sliwipi-dropdown-label" data-locale-text="name">Name</span>
+    <div id="sliwipi-sort-by-dropdown" class="popup_block_new" style="display: none;">
+      <div class="popup_body popup_menu">
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-sort-by-dropdown')" data-data="name" data-locale-text="name">Name</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-sort-by-dropdown')" data-data="playtime" data-locale-text="playtime">Playtime</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-sort-by-dropdown')" data-data="installedSize" data-locale-text="installed_size">Installed Size</a>
+      </div>
+    </div>
+  </div>
+  <div
+    id="sliwipi-filter-by-pulldown" class="pulldown global_action_link sliwipi-pulldown"
+    onmouseover="ShowMenu(this, 'sliwipi-filter-by-dropdown', 'right', 'bottom', true)"
+    onmouseout="HideMenu(this, 'sliwipi-filter-by-dropdown')"
+  >
+    <span data-locale-text="show">Show</span>
+    <span class="sliwipi-dropdown-label" data-locale-text="games_all">All Games</span>
+    <div id="sliwipi-filter-by-dropdown" class="popup_block_new" style="display: none;">
+      <div class="popup_body popup_menu">
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-filter-by-dropdown')" data-data="all" data-locale-text="games_all">All Games</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-filter-by-dropdown')" data-data="installed" data-locale-text="games_installed">Installed Games</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-filter-by-dropdown')" data-data="-installed" data-locale-text="games_not_installed">Not Installed Games</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-filter-by-dropdown')" data-data="played" data-locale-text="games_played">Played Games</a>
+        <a class="popup_menu_item" href="#" onclick="HideMenu(this.parentNode.parentNode.parentNode, 'sliwipi-filter-by-dropdown')" data-data="-played" data-locale-text="games_not_played">Not Played Games</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,12 @@
     "48": "img/es_48.png",
     "32": "img/es_32.png"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{1be309c5-3e4f-4b99-927d-bb500eb4fa88}",
+      "strict_min_version": "52.0"
+    }
+  },
   "manifest_version": 2,
   "browser_specific_settings": {
     "gecko": {
@@ -46,7 +52,10 @@
     "img/profile_styles/*/style.css",
     "img/profile_styles/*/preview.png",
     "localization/*/strings.json",
-    "js/steam/holidayprofile.js"
+    "js/steam/holidayprofile.js",
+    "js/sliwipi/thenBy.js",
+    "js/sliwipi/library-performance-injectable.js",
+    "library.html"
   ],
   "homepage_url": "https://es.isthereanydeal.com/",
   "content_scripts": [
@@ -89,7 +98,9 @@
         "*://steamcommunity.com/login/*",
         "*://steamcommunity.com/openid/*",
         "*://steamcommunity.com/chat/*",
-        "*://steamcommunity.com/tradeoffer/*"
+        "*://steamcommunity.com/tradeoffer/*",
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
       ],
       "js": [
         "js/lib/webextension-polyfill/browser-polyfill.js",
@@ -128,6 +139,34 @@
       ],
       "css": [
         "css/store/store_front.css"
+      ]
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/lib/DOMPurify/purify.js",
+        "js/config.js",
+        "js/core.js",
+        "js/language.js",
+        "js/sliwipi/library-performance.js"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/content/common.js",
+        "js/content/community.js"
+      ],
+      "css": [
+        "css/enhancedsteam.css",
+        "css/enhancedsteam-chrome.css"
       ]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -10,12 +10,6 @@
     "48": "img/es_48.png",
     "32": "img/es_32.png"
   },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "{1be309c5-3e4f-4b99-927d-bb500eb4fa88}",
-      "strict_min_version": "52.0"
-    }
-  },
   "manifest_version": 2,
   "browser_specific_settings": {
     "gecko": {
@@ -147,6 +141,7 @@
         "*://steamcommunity.com/*/games?tab=all*"
       ],
       "js": [
+        "js/lib/webextension-polyfill/browser-polyfill.js",
         "js/lib/DOMPurify/purify.js",
         "js/config.js",
         "js/core.js",

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -41,7 +41,10 @@
     "img/profile_styles/*/style.css",
     "img/profile_styles/*/preview.png",
     "localization/*/strings.json",
-    "js/steam/holidayprofile.js"
+    "js/steam/holidayprofile.js",
+    "js/sliwipi/thenBy.js",
+    "js/sliwipi/library-performance-injectable.js",
+    "library.html"
   ],
   "homepage_url": "https://es.isthereanydeal.com/",
   "content_scripts": [
@@ -84,7 +87,9 @@
         "*://steamcommunity.com/login/*",
         "*://steamcommunity.com/openid/*",
         "*://steamcommunity.com/chat/*",
-        "*://steamcommunity.com/tradeoffer/*"
+        "*://steamcommunity.com/tradeoffer/*",
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
       ],
       "js": [
         "js/lib/webextension-polyfill/browser-polyfill.js",
@@ -123,6 +128,35 @@
       ],
       "css": [
         "css/store/store_front.css"
+      ]
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/lib/webextension-polyfill/browser-polyfill.js",
+        "js/lib/DOMPurify/purify.js",
+        "js/config.js",
+        "js/core.js",
+        "js/language.js",
+        "js/sliwipi/library-performance.js"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/content/common.js",
+        "js/content/community.js"
+      ],
+      "css": [
+        "css/enhancedsteam.css",
+        "css/enhancedsteam-chrome.css"
       ]
     }
   ],

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -46,7 +46,10 @@
     "img/profile_styles/*/style.css",
     "img/profile_styles/*/preview.png",
     "localization/*/strings.json",
-    "js/steam/holidayprofile.js"
+    "js/steam/holidayprofile.js",
+    "js/sliwipi/thenBy.js",
+    "js/sliwipi/library-performance-injectable.js",
+    "library.html"
   ],
   "homepage_url": "https://es.isthereanydeal.com/",
   "content_scripts": [
@@ -89,7 +92,9 @@
         "*://steamcommunity.com/login/*",
         "*://steamcommunity.com/openid/*",
         "*://steamcommunity.com/chat/*",
-        "*://steamcommunity.com/tradeoffer/*"
+        "*://steamcommunity.com/tradeoffer/*",
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
       ],
       "js": [
         "js/lib/webextension-polyfill/browser-polyfill.js",
@@ -128,6 +133,35 @@
       ],
       "css": [
         "css/store/store_front.css"
+      ]
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/lib/webextension-polyfill/browser-polyfill.js",
+        "js/lib/DOMPurify/purify.js",
+        "js/config.js",
+        "js/core.js",
+        "js/language.js",
+        "js/sliwipi/library-performance.js"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "*://steamcommunity.com/*/games/?tab=all*",
+        "*://steamcommunity.com/*/games?tab=all*"
+      ],
+      "js": [
+        "js/content/common.js",
+        "js/content/community.js"
+      ],
+      "css": [
+        "css/enhancedsteam.css",
+        "css/enhancedsteam-firefox.css"
       ]
     }
   ],

--- a/options.html
+++ b/options.html
@@ -763,6 +763,43 @@
                         </div>
                     </div>
 
+                    <div id="community_library_section" class="content_section">
+                        <h2 data-locale-text="library_menu">Library</h2>
+                        <div class="parent_option option">
+                            <input type="checkbox" id="library_pagination" data-setting="library_pagination">
+                            <label for="library_pagination" data-locale-text="options.library_pagination">Enable library pagination</label>
+                        </div>
+                        <div class="option sub_option">
+                            <label for="library_rowsperpage" data-locale-text="options.library_rows_per_page">Rows per page:</label>
+                            <select id="library_rowsperpage" data-setting="library_rows_per_page">
+                                 <option value="5">5</option>
+                                 <option value="10">10</option>
+                                 <option value="15">15</option>
+                                 <option value="20">20</option>
+                                 <option value="25">25</option>
+                                 <option value="30">30</option>
+                                 <option value="50">50</option>
+                                 <option value="100">100</option>
+                                 <option value="150">150</option>
+                                 <option value="200">200</option>
+                                 <option value="250">250</option>
+                                 <option value="300">300</option>
+                                 <option value="500">500</option>
+                                 <option value="750">750</option>
+                                 <option value="1000">1000</option>
+                                 <option value="1500">1500</option>
+                             </select>  
+                         </div>
+                        <div class="option sub_option">
+                            <label for="library_default_sort" data-locale-text="options.library_default_sort">Default sorting:</label>
+                            <select id="library_default_sort" data-setting="library_default_sort">
+                                <option value="name" data-locale-text="name">Name</option>
+                                <option value="playtime" data-locale-text="playtime">Playtime</option>
+                             </select>
+                         </div>
+                         <div><!--empty div for sub_option to work--></div>
+                    </div>
+
                     <div id="community_group_section" class="content_section">
                         <h2 data-locale-text="options.group">Group</h2>
                         <h3 data-locale-text="options.group_links">Show group links to:</h3>
@@ -772,7 +809,7 @@
                         </div>
                     </div>
 
-        
+
                     <div id="community_general_section" class="content_section">
                         <h2 data-locale-text="options.general">General</h2>
                         <div class="option">


### PR DESCRIPTION
As original issue #622 explains, main reason behind this PR is to make "all games" page more responsive for user profiles with huge games list. This feature can be enabled/disabled in options, items per page and default sort order can be set in options too.

This PR is based on https://github.com/Yusyuriv/Sliwipi project. I tried my best to minimize it before including in AS, but at the same time I left it in separate files, because source is licensed under Apache License 2.0, and I have to keep notice and license intact.
Changes in comparison to original project (must state it according to Apache License 2.0): 
- removed wishlist part, it's not needed since Steam already implemented dynamic wishlists
- removed options part, it's integrated to AS options instead
- concatenated multiple files together to make it more compact


