### PR TITLE
Fix error on sub/bundle pages

### DIFF
--- a/js/content/common.js
+++ b/js/content/common.js
@@ -2051,7 +2051,6 @@ let Prices = (function(){
         this.bundleCallback = function(html) {};
 
         this._bundles = [];
-        this.appName = document.querySelector(".apphub_AppName").textContent;
     }
 
     Prices.prototype._getApiParams = function() {
@@ -2229,7 +2228,7 @@ let Prices = (function(){
             purchase += '<p class="package_contents">';
 
             let bundlePrice;
-            let appName = this.appName;
+            let appName = document.querySelector(".apphub_AppName").textContent;
 
             tiers.forEach((tier, t) => {
                 let tierNum = t + 1;


### PR DESCRIPTION
Regression from e8eed7a59f69d6474a3c1f2ca952ac30b10ec9cc
`document.querySelector(".apphub_AppName")` can be `null` on sub/bundle pages