### PR TITLE
Fix custom links spacing

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -369,7 +369,7 @@ let CommunityCommon = (function() {
         }
 
         html += `<span class="count_link_label">${name}</span>
-                <span class="profile_count_link_total"></span></a></div>`; // Steam spacing
+                <span class="profile_count_link_total">&nbsp;</span></a></div>`; // Steam spacing
 
         return html;
     };


### PR DESCRIPTION
Accidently removed in 41c7c2329409588dbcf368dec1ad54d9a1a4a2fe.