### PR TITLE
Remove inserting home.css

### DIFF
--- a/js/content/common.js
+++ b/js/content/common.js
@@ -376,15 +376,6 @@ let DOMHelper = (function(){
         document.head.appendChild(stylesheet);
     }
 
-    self.insertHomeCSS = function() {
-        self.insertStylesheet("//steamstore-a.akamaihd.net/public/css/v6/home.css");
-        let headerCtn = document.querySelector("div#global_header .content");
-        if (headerCtn) {
-            // Fixes displaced header, see #190
-            headerCtn.style.right = 0;
-        }
-    }
-
     self.insertScript = function({ src, content }, id, onload, isAsync = true) {
         let script = document.createElement("script");
 

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2781,9 +2781,6 @@ let SearchPageClass = (function(){
     SearchPageClass.prototype.endlessScrolling = function() {
         if (!SyncedStorage.get("contscroll")) { return; }
 
-        // Required for the loading wrapper
-        DOMHelper.insertHomeCSS();
-
         let result_count;
         document.querySelector(".search_pagination_right").style.display = "none";
 


### PR DESCRIPTION
Styles for the loading wrapper have been moved to https://steamstore-a.akamaihd.net/public/shared/css/shared_global.css, so inserting home.css on search pages doesn't seem to be doing anything apart from making the page look noticeably brighter. Should be safe to remove.