### PR TITLE
Added chat history link

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -797,9 +797,15 @@ let ProfileHomePageClass = (function(){
 
         // post history link
         HTML.afterEnd(node,
-                `<a class='popup_menu_item' id='es_posthistory' href='${window.location.pathname}/posthistory'>
+            `<a class='popup_menu_item' id='es_posthistory' href='${window.location.pathname}/posthistory'>
                 <img src='//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png'>&nbsp; ${Localization.str.post_history}
-                </a>`);
+            </a>`);
+
+        // chat history link
+        HTML.afterEnd(node,
+            `<a class="popup_menu_item" id="es_chathistory" href="//help.steampowered.com/accountdata/GetFriendMessagesLog">
+                <img src='//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png'>&nbsp; ${Localization.str.chat_history}
+            </a>`);
     };
 
     ProfileHomePageClass.prototype.inGameNameLink = function() {

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -24,6 +24,7 @@
     "contact": "Contact",
     "fav_emoticons_dragging": "Drag emoticons here to favorite them",
     "post_history": "View post history",
+    "chat_history": "View chat history",
     "add_nickname": "Add Nickname",
     "total_size": "Total Size",
     "dlc_details": "Downloadable Content Details",

--- a/localization/nl/strings.json
+++ b/localization/nl/strings.json
@@ -38,6 +38,7 @@
     "year": "Jaar",
     "show_progressbar": "Toon Augmented Steam progressie en statusbalk",
     "post_history": "Bekijk post geschiedenis",
+    "chat_history": "Bekijk chat geschiedenis",
     "add_nickname": "Bijnaam toevoegen",
     "total_size": "Totale grote",
     "dlc_details": "Downloadbare Content Details",


### PR DESCRIPTION
Adds a link to https://help.steampowered.com/en/accountdata/GetFriendMessagesLog
Perhaps in the future we can add some filters to that page.