### PR TITLE
Instant product code activation

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2497,7 +2497,7 @@ let RegisterKeyPageClass = (function(){
 
     RegisterKeyPageClass.prototype.instantActivation = function() {
         let params = new URLSearchParams(window.location.search);
-        if (!SyncedStorage.get("instantactivate") || !params.has("key")) { return; }
+        if (!SyncedStorage.get("instant_activate") || !params.has("key")) { return; }
 
         document.querySelector("[name=accept_ssa]").checked = true;
         document.querySelector("#register_btn").click();

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2491,8 +2491,17 @@ class AppPageClass extends StorePageClass {
 let RegisterKeyPageClass = (function(){
 
     function RegisterKeyPageClass() {
+        this.instantActivation();
         this.activateMultipleKeys();
     }
+
+    RegisterKeyPageClass.prototype.instantActivation = function() {
+        let params = new URLSearchParams(window.location.search);
+        if (!SyncedStorage.get("instantactivate") || !params.has("key")) { return; }
+
+        document.querySelector("[name=accept_ssa]").checked = true;
+        document.querySelector("#register_btn").click();
+    };
 
     RegisterKeyPageClass.prototype.activateMultipleKeys = function() {
         let activateModalTemplate = `<div id="es_activate_modal">

--- a/js/core.js
+++ b/js/core.js
@@ -629,6 +629,7 @@ SyncedStorage.defaults = {
     'show_alternative_linux_icon': false,
     'show_itad_button': false,
     'skip_got_steam': false,
+    'instant_activate': false,
 
     'hideaboutlinks': false,
     'installsteam': "show",

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -526,6 +526,7 @@
         "wishlist": "Items on your wishlist",
         "add_another_region": "Add",
         "skip_got_steam": "Skip the 'Got Steam?' window",
+        "instant_activate": "Automatically activate product code when visiting '/account/registerkey?key=CODE' store page",
         "store_general_thirdparty": "Options for information from 3rd-party sites",
         "purchase_dates": "Show apps purchase date on store pages",
         "show_badge_progress": "Show apps badge progress on store pages",

--- a/options.html
+++ b/options.html
@@ -493,6 +493,10 @@
                             <input type="checkbox" id="skip_got_steam" data-setting="skip_got_steam">
                             <label for="skip_got_steam" data-locale-text="options.skip_got_steam">Skip the 'Got Steam?' window</label>
                         </div>
+                        <div class="option">
+                            <input type="checkbox" id="instant_activate" data-setting="instant_activate">
+                            <label for="instant_activate" data-locale-text="options.instant_activate">Automatically activate product code when visiting '/account/registerkey?key=CODE' store page</label>
+                        </div>
                     </div>
         
                     <div id="store_thirdparty_section" class="content_section">


### PR DESCRIPTION
Saves an extra click. E.g. Useful for activating a lot of codes from a selection, or if you have to ninja a steam key.