### PR TITLE
Restore localization key help_translate

### DIFF
--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -61,6 +61,7 @@
     "clear_cache": "Clear cached data",
     "events": "Events",
     "translation": "Translation",
+    "help_translate": "Help us translate Augmented Steam over at POEditor",
     "lowest": "Lowest",
     "lowest_price": "Current Lowest Price:",
     "view_badge_progress": "View badge progress",


### PR DESCRIPTION
inadvertently removed in https://github.com/tfedor/AugmentedSteam/commit/5fa8f98aaa5d96c969fe6e9aeab3fb6b8adf2f1c#diff-7d69fd78b2194316dd711ae035f6e13c