### PR TITLE
Prevent spotlight elements from being selected in horizontalScrolling()

### DIFF
--- a/js/content/common.js
+++ b/js/content/common.js
@@ -1484,7 +1484,7 @@ let AugmentedSteam = (function() {
     self.horizontalScrolling = function() {
         if (!SyncedStorage.get("horizontalscrolling")) { return; }
 
-        for (let node of document.querySelectorAll(".slider_ctn")) {
+        for (let node of document.querySelectorAll(".slider_ctn:not(.spotlight)")) {
             new HorizontalScroller(
                 node.parentNode.querySelector("#highlight_strip, .store_horizontal_autoslider_ctn"),
                 node.querySelector(".slider_left"),


### PR DESCRIPTION
Fixes #816