### PR TITLE
Fixed several store url path RegExps

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3324,15 +3324,6 @@ let StatsPageClass = (function(){
     return StatsPageClass;
 })();
 
-let CuratorPageClass = (function(){
-
-    function CuratorPageClass() {
-        // no page-specific handling
-    }
-
-    return CuratorPageClass;
-})();
-
 
 let WishlistPageClass = (function(){
 
@@ -4108,10 +4099,6 @@ let TabAreaObserver = (function(){
 
         case /^\/stats(\/.*|$)/.test(path):
             (new StatsPageClass());
-            break;
-
-        case /^\/(?:curator|developer|dlc|publisher|franchise)\/.*/.test(path):
-            (new CuratorPageClass());
             break;
 
         case /^\/sale\/.*/.test(path):

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3919,15 +3919,6 @@ class UserNotes {
     }
 }
 
-let TagPageClass = (function(){
-
-    function TagPageClass() {
-
-    }
-
-    return TagPageClass;
-})();
-
 
 let StoreFrontPageClass = (function(){
 
@@ -4117,10 +4108,6 @@ let TabAreaObserver = (function(){
 
         case /^\/stats(\/.*|$)/.test(path):
             (new StatsPageClass());
-            break;
-
-        case /^\/(?:tags|genre)\//.test(path):
-            (new TagPageClass());
             break;
 
         case /^\/(?:curator|developer|dlc|publisher|franchise)\/.*/.test(path):

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -4099,23 +4099,23 @@ let TabAreaObserver = (function(){
             (new BundlePageClass(window.location.host + path));
             break;
 
-        case /^\/account\/registerkey(\/.*)?/.test(path):
+        case /^\/account\/registerkey(\/.*|$)/.test(path):
             (new RegisterKeyPageClass());
             return;
 
-        case /^\/account(\/)?/.test(path):
+        case /^\/account(\/)?$/.test(path):
             (new AccountPageClass());
             return;
 
-        case /^\/(steamaccount\/addfunds|digitalgiftcards\/selectgiftcard)/.test(path):
+        case /^\/(steamaccount\/addfunds|digitalgiftcards\/selectgiftcard(\/.*|$))/.test(path):
             (new FundsPageClass());
             break;
 
-        case /^\/search\/.*/.test(path):
+        case /^\/search(\/.*|$)/.test(path):
             (new SearchPageClass());
             break;
 
-        case /^\/stats\//.test(path):
+        case /^\/stats(\/.*|$)/.test(path):
             (new StatsPageClass());
             break;
 


### PR DESCRIPTION
Also removed unused TagPageClass.
I've checked each expression.
I'm aware they sometimes allow seemingly incorrect paths, however this is because steam also allows this.
For example:

https://store.steampowered.com/steamaccount/addfundskjdsakjdsakjkjsa