### PR TITLE
Add additional data to exported wishlist (Alternative)

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -3589,6 +3589,7 @@ let WishlistPageClass = (function(){
                     gameid: ["steam", `app/${appid}`],
                     title: data.name,
                     url: `https://store.steampowered.com/app/${appid}/`,
+                    type: data.type,
                     release_date: data.release_string,
                     note: this.notes[appid] || null,
                     price: data.subs[0] ? data.subs[0].price : false,


### PR DESCRIPTION
Closes #713

Okay, so stupid me didn't see #826 by @candela97 until I finished writing my PR.
I'm still opening this PR, because my solution is a bit different.
It directly uses Steam's formatting instead.
It also adds base price variables.
My solution assigns `false` to price, if no price exists (item not on sale), instead of price of 0.