### PR TITLE
Fix default values for priceCallback and bundleCallback

### DIFF
--- a/js/content/common.js
+++ b/js/content/common.js
@@ -2247,8 +2247,8 @@ let Prices = (function(){
         this.subids = [];
         this.bundleids = [];
 
-        this.priceCallback = function(type, id, node) {};
-        this.bundleCallback = function(html) {};
+        this.priceCallback = null;
+        this.bundleCallback = null;
 
         this._bundles = [];
     }


### PR DESCRIPTION
I'm not sure what these default values are for, but it seems to work fine without them and also prevents executing `_processBundles()` on wishlist entries (which can lead to errors if the app happens to be in a live bundle).