### PR TITLE
Create HTML.replace() method

### DIFF
--- a/js/content/community.js
+++ b/js/content/community.js
@@ -985,7 +985,7 @@ let ProfileHomePageClass = (function(){
         let rgProfileData = HTMLParser.getVariableFromDom("g_rgProfileData", "object");
         let friendSteamId = rgProfileData.steamid;
 
-        HTML.beforeBegin(sendButton,
+        HTML.replace(sendButton,
             `<span class="btn_profile_action btn_medium" id="profile_chat_dropdown_link">
                 <span>${sendButton.textContent}<img src="https://steamcommunity-a.akamaihd.net/public/images/profile/profile_action_dropdown.png"></span>
             </span>
@@ -1001,7 +1001,6 @@ let ProfileHomePageClass = (function(){
                     </a>
                 </div>
             </div>`);
-        sendButton.remove();
 
         document.querySelector("#btnWebChat").addEventListener("click", () => {
             ExtensionLayer.runInPageContext(chatId => { OpenFriendChatInWebChat(chatId); }, [ chatId ]);
@@ -2238,10 +2237,8 @@ let BadgesPageClass = (function(){
                         if (worth.value > 0) {
                             this.totalWorth += worth.value;
 
-                            let howToNode = node.querySelector(".how_to_get_card_drops");
-                            HTML.afterEnd(howToNode,
+                            HTML.replace(node.querySelector(".how_to_get_card_drops"),
                                 `<span class='es_card_drop_worth' data-es-card-worth='${worth.value}'>${Localization.str.drops_worth_avg} ${worth}</span>`);
-                            howToNode.remove();
                         }
                     }
                 }

--- a/js/core.js
+++ b/js/core.js
@@ -841,6 +841,24 @@ class HTML {
         return wrapper;
     }
 
+    static replace(node, html) {
+        if (typeof node == 'undefined' || node === null) {
+            console.warn(`${node} is not an Element.`);
+            return null;
+        }
+        if (typeof node == "string") {
+            node = document.querySelector(node);
+        }
+        if (!(node instanceof Element)) {
+            console.warn(`${node} is not an Element.`);
+            return null;
+        }
+
+        let newNode = HTML.element(html);
+        node.replaceWith(newNode);
+        return newNode;
+    }
+
     static adjacent(node, position, html) {
         if (typeof node == 'undefined' || node === null) {
             console.warn(`${node} is not an Element.`);

--- a/js/core.js
+++ b/js/core.js
@@ -822,25 +822,6 @@ class HTML {
         return node;
     }
 
-    static wrap(node, html) {
-        if (typeof node == 'undefined' || node === null) {
-            console.warn(`${node} is not an Element.`);
-            return null;
-        }
-        if (typeof node == "string") {
-            node = document.querySelector(node);
-        }
-        if (!(node instanceof Element)) {
-            console.warn(`${node} is not an Element.`);
-            return null;
-        }
-
-        let wrapper = HTML.element(html);
-        node.replaceWith(wrapper);
-        wrapper.appendChild(node);
-        return wrapper;
-    }
-
     static replace(node, html) {
         if (typeof node == 'undefined' || node === null) {
             console.warn(`${node} is not an Element.`);
@@ -857,6 +838,12 @@ class HTML {
         let newNode = HTML.element(html);
         node.replaceWith(newNode);
         return newNode;
+    }
+
+    static wrap(node, html) {
+        let wrapper = HTML.replace(node, html);
+        wrapper.append(node);
+        return wrapper;
     }
 
     static adjacent(node, position, html) {


### PR DESCRIPTION
Replaces an oldNode with a newNode. Can be used instead of having to insert a newNode next to an oldNode, then removing the oldNode.