### PR TITLE
Default value for rows in applyCountFilter

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2788,7 +2788,7 @@ let SearchPageClass = (function(){
         }
     }
 
-    function applyCountFilter(rows) {
+    function applyCountFilter(rows = document.querySelectorAll(".search_result_row")) {
 
         let minCount, maxCount;
 


### PR DESCRIPTION
This fixes `Uncaught TypeError: rows is not iterable` when using the review count filter.