### PR TITLE
Simplify MarketListingPageClass

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2848,7 +2848,7 @@ input[type=checkbox].es_dlc_selection:checked + label {
 
 /***************************************
  * Market listings pages
- * add_sold_amount()
+ * FSoldAmountLastDay
  **************************************/
 #market_commodity_orders_header {
   position: relative;
@@ -2870,6 +2870,23 @@ input[type=checkbox].es_dlc_selection:checked + label {
 .market_section_title .es_sold_amount:after {
   content: ")";
 }
+
+/***************************************
+ * Market listings pages
+ * FBadgePageLink
+ **************************************/
+.es_marketlistings_btn {
+  float: right;
+  margin-top: -10px;
+}
+.es_marketlistings_btn img[src$="/ico_cards.png"] {
+  margin: 7px 0;
+  width: 26px;
+  height: 16px;
+  border: 0;
+  vertical-align: top;
+}
+
 
 /* right column 3rd party sites buttons */
 .rightcol.game_meta_data .es_app_btn {

--- a/src/js/Content/Features/Community/MarketListing/CMarketListing.js
+++ b/src/js/Content/Features/Community/MarketListing/CMarketListing.js
@@ -1,5 +1,4 @@
 import ContextType from "../../../Modules/Context/ContextType";
-import {GameId} from "../../../../Core/GameId";
 import {CCommunityBase} from "../CCommunityBase";
 import FSoldAmountLastDay from "./FSoldAmountLastDay";
 import FBackgroundPreviewLink from "./FBackgroundPreviewLink";
@@ -16,6 +15,8 @@ export class CMarketListing extends CCommunityBase {
             FPriceHistoryZoomControl,
         ]);
 
-        this.appid = GameId.getAppid(window.location.href);
+        const m = window.location.href.match(/\/(\d+)\/(.+)$/);
+        this.appid = Number(m[1]);
+        this.marketHashName = m[2];
     }
 }

--- a/src/js/Content/Features/Community/MarketListing/FBackgroundPreviewLink.js
+++ b/src/js/Content/Features/Community/MarketListing/FBackgroundPreviewLink.js
@@ -4,7 +4,7 @@ import {Feature, User} from "../../../modulesContent";
 export default class FBackgroundPreviewLink extends Feature {
 
     checkPrerequisites() {
-        return this.context.appid === 753;
+        return this.context.appid === 753 && User.isSignedIn;
     }
 
     apply() {

--- a/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
+++ b/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
@@ -3,6 +3,10 @@ import {HTML, Localization} from "../../../../modulesCore";
 
 export default class FBadgePageLink extends Feature {
 
+    checkPrerequisites() {
+        return this.context.appid === 753;
+    }
+
     apply() {
 
         const gameAppId = parseInt(this.context.marketHashName);

--- a/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
+++ b/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
@@ -14,12 +14,12 @@ export default class FBadgePageLink extends Feature {
 
         const cardType = /Foil(%20Trading%20Card)?%29/.test(this.context.marketHashName) ? "?border=1" : "";
 
-        HTML.beforeEnd("div.market_listing_nav",
-            `<a class="btn_grey_grey btn_medium" href="https://steamcommunity.com/my/gamecards/${gameAppId + cardType}" style="float: right; margin-top: -10px;" target="_blank">
-            <span>
-                <img src="https://store.steampowered.com/public/images/v6/ico/ico_cards.png" style="margin: 7px 0;" width="24" height="16" border="0" align="top">
-                ${Localization.str.view_badge}
-            </span>
-        </a>`);
+        HTML.beforeEnd("#mainContents .market_listing_nav",
+            `<a class="es_marketlistings_btn btn_grey_grey btn_medium" href="//steamcommunity.com/my/gamecards/${gameAppId + cardType}" target="_blank">
+                <span>
+                    <img src="//store.steampowered.com/public/images/v6/ico/ico_cards.png">
+                    ${Localization.str.view_badge}
+                </span>
+            </a>`);
     }
 }

--- a/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
+++ b/src/js/Content/Features/Community/MarketListing/FBadgePageLink.js
@@ -5,9 +5,10 @@ export default class FBadgePageLink extends Feature {
 
     apply() {
 
-        const gameAppId = parseInt((document.URL.match(/\/753\/([0-9]+)-/) || [0, 0])[1]);
-        const cardType = document.URL.match("Foil(%20Trading%20Card)?%29") ? "?border=1" : "";
+        const gameAppId = parseInt(this.context.marketHashName);
         if (!gameAppId || gameAppId === 753) { return; }
+
+        const cardType = /Foil(%20Trading%20Card)?%29/.test(this.context.marketHashName) ? "?border=1" : "";
 
         HTML.beforeEnd("div.market_listing_nav",
             `<a class="btn_grey_grey btn_medium" href="https://steamcommunity.com/my/gamecards/${gameAppId + cardType}" style="float: right; margin-top: -10px;" target="_blank">

--- a/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
+++ b/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
@@ -16,7 +16,10 @@ export default class FSoldAmountLastDay extends Feature {
                    ${Localization.str.sold_last_24.replace("__sold__", `<span class="market_commodity_orders_header_promote">${data.volume || 0}</span>`)}
                </div>`;
 
-        HTML.beforeBegin(".market_commodity_buy_button", soldHtml);
+        const nodes = document.querySelectorAll("#market_commodity_order_spread > :nth-child(2) .market_commodity_orders_header, #pricehistory .jqplot-title, #listings .market_section_title");
+        for (const node of nodes) {
+            HTML.beforeEnd(node, soldHtml);
+        }
 
         /*
          * TODO where is this observer applied?

--- a/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
+++ b/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
@@ -1,21 +1,14 @@
 import {HTML, Localization} from "../../../../modulesCore";
-import {CurrencyManager, DOMHelper, Feature, RequestData, User} from "../../../modulesContent";
+import {CurrencyManager, Feature, RequestData, User} from "../../../modulesContent";
 
 export default class FSoldAmountLastDay extends Feature {
-
-    checkPrerequisites() {
-        return this.context.appid !== null;
-    }
 
     async apply() {
 
         const country = User.storeCountry;
         const currencyNumber = CurrencyManager.currencyTypeToNumber(CurrencyManager.storeCurrency);
 
-        const link = DOMHelper.selectLastNode(document, '.market_listing_nav a[href^="https://steamcommunity.com/market/"]').href;
-        const marketHashName = (link.match(/\/\d+\/(.+)$/) || [])[1];
-
-        const data = await RequestData.getJson(`https://steamcommunity.com/market/priceoverview/?appid=${this.context.appid}&country=${country}&currency=${currencyNumber}&market_hash_name=${marketHashName}`);
+        const data = await RequestData.getJson(`https://steamcommunity.com/market/priceoverview/?appid=${this.context.appid}&country=${country}&currency=${currencyNumber}&market_hash_name=${this.context.marketHashName}`);
         if (!data.success) { return; }
 
         const soldHtml

--- a/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
+++ b/src/js/Content/Features/Community/MarketListing/FSoldAmountLastDay.js
@@ -21,15 +21,11 @@ export default class FSoldAmountLastDay extends Feature {
             HTML.beforeEnd(node, soldHtml);
         }
 
-        /*
-         * TODO where is this observer applied?
-         * let observer = new MutationObserver(function(){
-         *  if (!document.querySelector("#pricehistory .es_sold_amount")) {
-         *      document.querySelector(".jqplot-title").insertAdjacentHTML("beforeend", soldHtml);
-         *  }
-         *  return true;
-         * });
-         * observer.observe(document, {}); // .jqplot-event-canvas
-         */
+        // retain sold amount info after changing zoom controls
+        new MutationObserver(() => {
+            if (!document.querySelector("#pricehistory .es_sold_amount")) {
+                HTML.beforeEnd("#pricehistory .jqplot-title", soldHtml);
+            }
+        }).observe(document.querySelector("#pricehistory"), {"childList": true});
     }
 }


### PR DESCRIPTION
1. Restore displaying sold amount info as done by ES -- also appears above the "Median Sale Prices" graph and "Listings" title for commodities like https://steamcommunity.com/market/listings/264710/Planet%204546B%20Postcard
2. Add sign-in check for addBackgroundPreviewLink()