### PR TITLE
Fix HTML scripts

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -869,7 +869,20 @@ class HTML {
     }
 
     static wrap(node, html) {
-        let wrapper = HTML.replace(node, html);
+        if (typeof node == 'undefined' || node === null) {
+            console.warn(`${node} is not an Element.`);
+            return null;
+        }
+        if (typeof node == "string") {
+            node = document.querySelector(node);
+        }
+        if (!(node instanceof Element)) {
+            console.warn(`${node} is not an Element.`);
+            return null;
+        }
+
+        let wrapper = HTML.element(html);
+        node.replaceWith(wrapper);
         wrapper.append(node);
         return wrapper;
     }

--- a/js/core.js
+++ b/js/core.js
@@ -863,9 +863,8 @@ class HTML {
             return null;
         }
 
-        let newNode = HTML.element(html);
-        node.replaceWith(newNode);
-        return newNode;
+        node.outerHTML = DOMPurify.sanitize(html);
+        return node;
     }
 
     static wrap(node, html) {


### PR DESCRIPTION
1. A selector string should be allowed for the first argument, reverts https://github.com/tfedor/AugmentedSteam/commit/d43cceffa5024a099405c01c61cb983a1fbae515.
2. Use `outerHTML` to replace elements