### PR TITLE
Rework DLC checkbox style

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2712,9 +2712,14 @@ img.astats_icon {
   margin-right: 8px;
   line-height: normal;
   text-decoration: none;
-}
-#es_dlc_option_button:hover {
   cursor: pointer;
+  color: #67c1f5;
+}
+#es_dlc_option_button::after {
+  content: "▼";
+}
+#es_dlc_option_button.open::after {
+  content: "▲";
 }
 #es_dlc_option_panel {
   background: url('https://steamcommunity-a.akamaihd.net/public/images/profile/profile_header_bg_texture.jpg');

--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -2735,37 +2735,37 @@ img.astats_icon {
   cursor: pointer;
 }
 
-/* hide dlc flag due to checkboxes */
+/* hide dlc flag due to checkboxes (if highlighting is disabled) */
 .game_area_dlc_row:hover .ds_flag {
   display: none;
 }
+/* move title out of the way */
+.game_area_dlc_name {
+  margin-left: 23px;
+}
 
-.es_dlc_selection {
-  cursor: default;
-}
-input[type=checkbox].es_dlc_selection {
+label.es_dlc_select {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
+  padding: 4px 11px 1px;
+  top: 0px;
+  left: 1px;
 }
-input[type=checkbox].es_dlc_selection + label {
-  padding-left: 20px;
-  height: 13px;
-  display: inline-block;
-  line-height: 13px;
-  background-repeat: no-repeat;
-  background-position: 0 0;
-  vertical-align: middle;
-  cursor: default;
-  z-index: 99;
+label.es_dlc_select > input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: #545454;
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #343434;
+  outline: none;
 }
-input[type=checkbox].es_dlc_selection:checked + label {
-  background-position: 0 -13px;
+label.es_dlc_select > input:checked::after {
+  content: "✔";
+  color: #8bc53f;
+  font-size: 12px;
+  position: absolute;
+  bottom: 3px;
+  left: 14px;
 }
 
 /***************************************

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2117,17 +2117,14 @@ class AppPageClass extends StorePageClass {
                 </div>`);
         }
 
-        let form = document.createElement("form");
-        form.setAttribute("name", "add_selected_dlc_to_cart");
-        form.setAttribute("action", "/cart/");
-        form.setAttribute("method", "POST");
-        form.setAttribute("id", "es_selected_cart");
+        let cartForm = document.createElement("form");
+        cartForm.name = "add_selected_dlc_to_cart";
+        cartForm.action = "/cart/";
+        cartForm.method = "POST";
 
         let cartBtn = dlcs.querySelector("#es_selected_btn");
-        cartBtn.insertAdjacentElement("beforebegin", form);
-        cartBtn.addEventListener("click", () => {
-            form.submit();
-        });
+        cartBtn.insertAdjacentElement("beforebegin", cartForm);
+        cartBtn.addEventListener("click", () => { cartForm.submit(); });
 
         HTML.afterEnd(dlcs.querySelector(".gradientbg"),
             `<div id="es_dlc_option_panel">
@@ -2147,7 +2144,7 @@ class AppPageClass extends StorePageClass {
         });
 
         dlcs.querySelector("#wl_dlc_check").addEventListener("click", () => {
-            let nodes = dlcs.querySelectorAll(".ds_wishlist input:not(:checked)");
+            let nodes = dlcs.querySelectorAll(".game_area_dlc_row.ds_wishlist input:not(:checked)");
             for (let node of nodes) {
                 node.checked = true;
                 node.dispatchEvent(change);
@@ -2173,7 +2170,6 @@ class AppPageClass extends StorePageClass {
         dlcs.addEventListener("change", e => {
             if (!e.target.parentNode.classList.contains("es_dlc_select")) { return; }
 
-            let cartForm = dlcs.querySelector("#es_selected_cart");
             cartForm.innerHTML = "";
 
             let inputAction = document.createElement("input");

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2086,17 +2086,12 @@ class AppPageClass extends StorePageClass {
         let dlcs = document.querySelector(".game_area_dlc_section");
         if (!dlcs || !dlcs.querySelector(".game_area_dlc_list")) { return; }
 
-        let imgUrl = ExtensionResources.getURL("img/check_sheet.png");
         for (let dlc of dlcs.querySelectorAll(".game_area_dlc_row")) {
-            if (dlc.querySelector("input")) {
-                let value = dlc.querySelector("input").value;
+            let subid = dlc.querySelector("input[name^=subid]");
+            if (!subid) { continue; }
 
-                HTML.afterBegin(dlc.querySelector(".game_area_dlc_name"),
-                    `<input type="checkbox" class="es_dlc_selection" id="es_select_dlc_${value}" value="${value}">
-                    <label for="es_select_dlc_${value}" style="background-image: url(${imgUrl});"></label>`);
-            } else {
-                dlc.querySelector(".game_area_dlc_name").style.marginLeft = "23px";
-            }
+            HTML.afterBegin(dlc.querySelector(".game_area_dlc_name"),
+                `<label class="es_dlc_select"><input type="checkbox" value="${subid.value}"></label>`);
         }
 
         let expandedNode = dlcs.querySelector("#game_area_dlc_expanded");
@@ -2179,7 +2174,7 @@ class AppPageClass extends StorePageClass {
         });
 
         dlcs.addEventListener("change", e => {
-            if (!e.target.classList.contains("es_dlc_selection")) { return; }
+            if (!e.target.parentNode.classList.contains("es_dlc_select")) { return; }
 
             let cartForm = dlcs.querySelector("#es_selected_cart");
             cartForm.innerHTML = "";
@@ -2196,7 +2191,7 @@ class AppPageClass extends StorePageClass {
 
             cartForm.append(inputAction, inputSessionId);
 
-            let nodes = dlcs.querySelectorAll(".es_dlc_selection:checked");
+            let nodes = dlcs.querySelectorAll(".game_area_dlc_row input:checked");
             for (let node of nodes) {
 
                 let inputSubId = document.createElement("input");

--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2163,14 +2163,11 @@ class AppPageClass extends StorePageClass {
         });
 
         HTML.beforeEnd(dlcs.querySelector(".gradientbg"),
-            `<a id="es_dlc_option_button">${Localization.str.dlc_select.select} ▼</a>`);
+            `<a id="es_dlc_option_button">${Localization.str.dlc_select.select} </a>`);
 
         dlcs.querySelector("#es_dlc_option_button").addEventListener("click", e => {
+            e.target.classList.toggle("open");
             dlcs.querySelector("#es_dlc_option_panel").classList.toggle("esi-shown");
-
-            e.target.textContent = e.target.textContent.includes("▼")
-                ? `${Localization.str.dlc_select.select} ▲`
-                : `${Localization.str.dlc_select.select} ▼`;
         });
 
         dlcs.addEventListener("change", e => {


### PR DESCRIPTION
Use modifications to the browser's native checkbox styling instead of a custom background, also added some padding to the label to make them easier to select.

Needs testing on versions of Firefox, because I'm not sure how the behaviour of `-moz-appearance: none` differs.