### PR TITLE
"Show Performance Survey" option added (default true)

### DIFF
--- a/js/content/store.js
+++ b/js/content/store.js
@@ -2008,6 +2008,7 @@ class AppPageClass extends StorePageClass {
     }
 
     addSurveyData(result) {
+        if (!SyncedStorage.get("show_performance_survey")) { return; }
         if (this.isVideo()) { return; }
         if (!result.survey) { return; }
 

--- a/js/core.js
+++ b/js/core.js
@@ -740,6 +740,7 @@ SyncedStorage.defaults = {
     'context_steamdb': false,
     'context_steamdb_instant': false,
     'context_steam_keys': false,
+    'show_performance_survey': true
 };
 
 

--- a/localization/en/strings.json
+++ b/localization/en/strings.json
@@ -569,6 +569,7 @@
         "profile_showcase_twitch": "Add a showcase for Twitch.tv if there is a link",
         "profile_showcase_own_twitch": "... including your own profile",
         "profile_showcase_twitch_profileonly": "... only if the link is in the Profile Summary",
+        "show_performance_survey": "Show Performance Survey",
         "lang": {
             "english": "English",
             "brazilian": "Portuguese-Brazil",

--- a/options.html
+++ b/options.html
@@ -510,6 +510,10 @@
                             <input type="checkbox" id="skip_got_steam" data-setting="skip_got_steam">
                             <label for="skip_got_steam" data-locale-text="options.skip_got_steam">Skip the 'Got Steam?' window</label>
                         </div>
+                        <div class="option">
+                            <input type="checkbox" id="show_performance_survey" data-setting="show_performance_survey">
+                            <label for="show_performance_survey" data-locale-text="options.show_performance_survey">Show Performance Survey</label>
+                        </div>
                     </div>
         
                     <div id="store_thirdparty_section" class="content_section">


### PR DESCRIPTION
New option under Store -> General that allows user to toggle the "Performance Survey" section of the store page.

It defaults to true 

#935 