### PR TITLE
Split out FViewSteamId from FCommunityProfileLinks, fix imports

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1823,28 +1823,25 @@ img.astats_icon {
 }
 
 /***************************************
- * User's SteamIDs
+ * User profiles
+ * FViewSteamId
  **************************************/
 .es-copy {
   display: flex;
   align-items: baseline;
 }
-
-.es-copy:hover .es-copy__id{
+.es-copy:hover .es-copy__id {
   text-decoration: underline;
 }
-
 .es-copy:hover .es-copy__icon {
   opacity: 1;
 }
-
 .es-copy .es-copy__icon {
   filter: invert(55%);
   height: 1.2em;
   margin-left: 5px;
   opacity: 0;
 }
-
 .es-copy__copied {
   opacity: 0;
   transition: opacity 200ms;
@@ -1855,7 +1852,6 @@ img.astats_icon {
 .es-copy.is-copied .es-copy__copied {
   opacity: 1;
 }
-
 
 /***************************************
  * Users profiles

--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -10,6 +10,7 @@ import FProfileDropdownOptions from "./FProfileDropdownOptions";
 import FCustomStyle from "./FCustomStyle";
 import FTwitchShowcase from "./FTwitchShowcase";
 import FChatDropdownOptions from "./FChatDropdownOptions";
+import FViewSteamId from "./FViewSteamId";
 
 export class CProfileHome extends CCommunityBase {
 
@@ -47,6 +48,7 @@ export class CProfileHome extends CCommunityBase {
             FCustomStyle,
             FTwitchShowcase,
             FChatDropdownOptions,
+            FViewSteamId,
         ]);
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
@@ -1,67 +1,9 @@
-import {ExtensionResources, HTML, Language, Localization, SyncedStorage} from "../../../../modulesCore";
-import {Clipboard, CommunityUtils, Feature, SteamId} from "../../../modulesContent";
-import {Page} from "../../Page";
+import {HTML, Language, SyncedStorage} from "../../../../modulesCore";
+import {CommunityUtils, Feature, SteamId} from "../../../modulesContent";
 
 export default class FCommunityProfileLinks extends Feature {
 
     apply() {
-        function copySteamId(e) {
-            const elem = e.target.closest(".es-copy");
-            if (!elem) { return; }
-
-            Clipboard.set(elem.querySelector(".es-copy__id").innerText);
-
-            const lastCopied = document.querySelector(".es-copy.is-copied");
-            if (lastCopied) {
-                lastCopied.classList.remove("is-copied");
-            }
-
-            elem.classList.add("is-copied");
-            window.setTimeout(() => { elem.classList.remove("is-copied"); }, 2000);
-        }
-
-        function showSteamIdDialog() {
-            document.addEventListener("click", copySteamId);
-
-            const imgUrl = ExtensionResources.getURL("img/clippy.svg");
-
-            const steamId = new SteamId.Detail(SteamId.getSteamId());
-            const ids = [
-                steamId.id2,
-                steamId.id3,
-                steamId.id64,
-                `https://steamcommunity.com/profiles/${steamId.id64}`
-            ];
-
-            const copied = Localization.str.copied;
-            let html = "";
-            for (const id of ids) {
-                if (!id) { continue; }
-                html += `<p><a class="es-copy"><span class="es-copy__id">${id}</span><img src='${imgUrl}' class="es-copy__icon"><span class="es-copy__copied">${copied}</span></a></p>`;
-            }
-
-            Page.runInPageContext((steamidOfUser, html, close) => {
-                const f = window.SteamFacade;
-                f.hideMenu("profile_action_dropdown_link", "profile_action_dropdown");
-
-                const dialog = f.showAlertDialog(
-                    steamidOfUser.replace("__user__", f.global("g_rgProfileData").personaname),
-                    html,
-                    close
-                );
-
-                return new Promise(resolve => {
-                    dialog.done(() => { resolve(); });
-                });
-            },
-            [
-                Localization.str.steamid_of_user,
-                html,
-                Localization.str.close,
-            ],
-            "closeDialog")
-                .then(() => { document.removeEventListener("click", copySteamId); });
-        }
 
         const steamId = SteamId.getSteamId();
 
@@ -155,27 +97,6 @@ export default class FCommunityProfileLinks extends Feature {
             htmlstr += CommunityUtils.makeProfileLink("custom", link, name, iconType, icon);
         }
 
-        // profile steamid
-        if (SyncedStorage.get("profile_steamid")) {
-            const dropdown = document.querySelector("#profile_action_dropdown .popup_body.popup_menu");
-            if (dropdown) {
-                HTML.beforeEnd(dropdown,
-                    `<a class="popup_menu_item" id="es_steamid">
-                        <img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
-                    </a>`);
-            } else {
-                const actions = document.querySelector(".profile_header_actions");
-                if (actions) {
-                    HTML.beforeEnd(actions,
-                        `<a class="btn_profile_action btn_medium" id="es_steamid">
-                            <span>${Localization.str.view_steamid}</span>
-                        </a>`);
-                }
-            }
-
-            document.querySelector("#es_steamid").addEventListener("click", showSteamIdDialog);
-        }
-
         // Insert the links HMTL into the page
         if (htmlstr) {
             const linksNode = document.querySelector(".profile_item_links");
@@ -187,7 +108,5 @@ export default class FCommunityProfileLinks extends Feature {
                 HTML.afterEnd(rightColNode, '<div style="clear: both;"></div>');
             }
         }
-
-
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
+++ b/src/js/Content/Features/Community/ProfileHome/FViewSteamId.js
@@ -1,0 +1,94 @@
+import {ExtensionResources, HTML, Localization, SyncedStorage} from "../../../../modulesCore";
+import {Clipboard, Feature, SteamId, SteamIdDetail} from "../../../modulesContent";
+import {Page} from "../../Page";
+
+export default class FViewSteamId extends Feature {
+
+    checkPrerequisites() {
+        return SyncedStorage.get("profile_steamid");
+    }
+
+    apply() {
+
+        function copySteamId(e) {
+            const elem = e.target.closest(".es-copy");
+            if (!elem) { return; }
+
+            Clipboard.set(elem.querySelector(".es-copy__id").innerText);
+
+            const lastCopied = document.querySelector(".es-copy.is-copied");
+            if (lastCopied) {
+                lastCopied.classList.remove("is-copied");
+            }
+
+            elem.classList.add("is-copied");
+            window.setTimeout(() => { elem.classList.remove("is-copied"); }, 2000);
+        }
+
+        function showSteamIdDialog() {
+            document.addEventListener("click", copySteamId);
+
+            const imgUrl = ExtensionResources.getURL("img/clippy.svg");
+
+            const steamId = new SteamIdDetail(SteamId.getSteamId());
+            const ids = [
+                steamId.id2,
+                steamId.id3,
+                steamId.id64,
+                `https://steamcommunity.com/profiles/${steamId.id64}`
+            ];
+
+            let html = "";
+            for (const id of ids) {
+                if (!id) { continue; }
+                html += `<p>
+                            <a class="es-copy">
+                                <span class="es-copy__id">${id}</span>
+                                <img src="${imgUrl}" class="es-copy__icon">
+                                <span class="es-copy__copied">${Localization.str.copied}</span>
+                            </a>
+                        </p>`;
+            }
+
+            Page.runInPageContext((steamidOfUser, html, close) => {
+                const f = window.SteamFacade;
+                f.hideMenu("profile_action_dropdown_link", "profile_action_dropdown");
+
+                const dialog = f.showAlertDialog(
+                    steamidOfUser.replace("__user__", f.global("g_rgProfileData").personaname),
+                    html,
+                    close
+                );
+
+                return new Promise(resolve => {
+                    dialog.done(() => { resolve(); });
+                });
+            },
+            [
+                Localization.str.steamid_of_user,
+                html,
+                Localization.str.close,
+            ],
+            "closeDialog")
+                .then(() => { document.removeEventListener("click", copySteamId); });
+        }
+
+        const dropdown = document.querySelector("#profile_action_dropdown .popup_body.popup_menu");
+        if (dropdown) {
+            HTML.beforeEnd(dropdown,
+                `<a class="popup_menu_item" id="es_steamid">
+                    <img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/iconForums.png">&nbsp; ${Localization.str.view_steamid}
+                </a>`);
+        } else {
+            const actions = document.querySelector(".profile_header_actions");
+            if (actions) {
+                HTML.beforeEnd(actions,
+                    `<a class="btn_profile_action btn_medium" id="es_steamid">
+                        <span>${Localization.str.view_steamid}</span>
+                    </a>`);
+            }
+        }
+
+        document.querySelector("#es_steamid").addEventListener("click", showSteamIdDialog);
+    }
+}


### PR DESCRIPTION
Split out the view steamid feature to its own module, since it has little to do with custom links now.