### PR TITLE
Minor improvements to FChatDropdownOptions

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2433,6 +2433,21 @@ label[for="show_common_games"] {
 }
 
 /***************************************
+ * User profiles
+ * FChatDropdownOptions
+ **************************************/
+#profile_chat_dropdown {
+  display: none;
+}
+#profile_chat_dropdown .shadow_content {
+  box-shadow: 0 0 12px #000;
+}
+#profile_chat_dropdown .popup_menu_item img {
+  position: relative;
+  top: 3px;
+}
+
+/***************************************
  * addCustomTags() to community guides
  *
  **************************************/

--- a/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
+++ b/src/js/Content/Features/Community/ProfileHome/FChatDropdownOptions.js
@@ -13,41 +13,40 @@ export default class FChatDropdownOptions extends Feature {
         const sendButton = document.querySelector("div.profile_header_actions > a[href*=OpenFriendChat]");
         if (!sendButton) { return; }
 
-        const m = sendButton.href.match(/javascript:OpenFriendChat\( '(\d+)'.*\)/);
-        if (!m) { return; }
-        const chatId = m[1];
-
-        const rgProfileData = HTMLParser.getVariableFromDom("g_rgProfileData", "object");
-        const friendSteamId = rgProfileData.steamid;
+        const {"steamid": friendSteamId} = HTMLParser.getVariableFromDom("g_rgProfileData", "object");
 
         HTML.replace(sendButton,
             `<span class="btn_profile_action btn_medium" id="profile_chat_dropdown_link">
-                <span>${sendButton.textContent}<img src="https://steamcommunity-a.akamaihd.net/public/images/profile/profile_action_dropdown.png"></span>
+                <span>${sendButton.textContent}<img src="//steamcommunity-a.akamaihd.net/public/images/profile/profile_action_dropdown.png"></span>
             </span>
-            <div class="popup_block" id="profile_chat_dropdown" style="visibility: visible; top: 168px; left: 679px; display: none; opacity: 1;">
-                <div class="popup_body popup_menu shadow_content" style="box-shadow: 0 0 12px #000">
-                    <a id="btnWebChat" class="popup_menu_item webchat">
-                        <img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
+            <div class="popup_block" id="profile_chat_dropdown">
+                <div class="popup_body popup_menu shadow_content">
+                    <a id="btnWebChat" class="popup_menu_item">
+                        <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.web_browser_chat}
                     </a>
                     <a class="popup_menu_item" href="steam://friends/message/${friendSteamId}">
-                        <img src="https://steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
+                        <img src="//steamcommunity-a.akamaihd.net/public/images/skin_1/icon_btn_comment.png">
                         &nbsp; ${Localization.str.steam_client_chat}
                     </a>
                 </div>
             </div>`);
 
         document.querySelector("#btnWebChat").addEventListener("click", () => {
-            Page.runInPageContext(chatId => { window.SteamFacade.openFriendChatInWebChat(chatId); }, [chatId]);
+            Page.runInPageContext(steamId => {
+                window.SteamFacade.openFriendChatInWebChat(steamId);
+            }, [friendSteamId]);
         });
 
         document.querySelector("#profile_chat_dropdown_link").addEventListener("click", () => {
             Page.runInPageContext(() => {
-                window.SteamFacade.showMenu(
-                    document.querySelector("#profile_chat_dropdown_link"),
-                    "profile_chat_dropdown",
-                    "right"
-                );
+                window.SteamFacade.showMenu("profile_chat_dropdown_link", "profile_chat_dropdown", "right");
+            });
+        });
+
+        document.querySelector("#profile_chat_dropdown").addEventListener("click", () => {
+            Page.runInPageContext(() => {
+                window.SteamFacade.hideMenu("profile_chat_dropdown_link", "profile_chat_dropdown");
             });
         });
     }


### PR DESCRIPTION
1. Simplify the code a bit: `chatId === friendSteamId`, see https://github.com/SteamDatabase/SteamTracking/blob/5b23cdaef416e2e7f09b4b752970f5f5b38742ef/steamcommunity.com/public/shared/javascript/shared_global.js#L94
2. Hide the menu after clicking on an option (Web chat opens a new window, client chat opens the client)
3. Fix img icon position, move styles to CSS file