### PR TITLE
Simplify re-export syntax in aggregated modules

### DIFF
--- a/src/js/Content/modulesContent.js
+++ b/src/js/Content/modulesContent.js
@@ -1,60 +1,35 @@
 
-import {CommunityUtils} from "./Modules/Community/CommunityUtils";
-import {ProfileData} from "./Modules/Community/ProfileData";
+export {CommunityUtils} from "./Modules/Community/CommunityUtils";
+export {ProfileData} from "./Modules/Community/ProfileData";
 
-import {Context} from "./Modules/Context/Context";
-import ContextType from "./Modules/Context/ContextType";
+export {Context} from "./Modules/Context/Context";
+export {default as ContextType} from "./Modules/Context/ContextType";
 
-import {DynamicStore} from "./Modules/Data/DynamicStore";
-import {Inventory} from "./Modules/Data/Inventory";
+export {DynamicStore} from "./Modules/Data/DynamicStore";
+export {Inventory} from "./Modules/Data/Inventory";
 
-import {CallbackFeature} from "./Modules/Feature/CallbackFeature";
-import {Feature} from "./Modules/Feature/Feature";
-import {FeatureManager} from "./Modules/Feature/FeatureManager";
+export {CallbackFeature} from "./Modules/Feature/CallbackFeature";
+export {Feature} from "./Modules/Feature/Feature";
+export {FeatureManager} from "./Modules/Feature/FeatureManager";
 
-import {ConfirmDialog} from "./Modules/Widgets/ConfirmDialog";
-import {HorizontalScroller} from "./Modules/Widgets/HorizontalScroller";
-import {ProgressBar} from "./Modules/Widgets/ProgressBar";
-import {Sortbox} from "./Modules/Widgets/SortBox";
+export {ConfirmDialog} from "./Modules/Widgets/ConfirmDialog";
+export {HorizontalScroller} from "./Modules/Widgets/HorizontalScroller";
+export {ProgressBar} from "./Modules/Widgets/ProgressBar";
+export {Sortbox} from "./Modules/Widgets/SortBox";
 
-import {AugmentedSteam} from "./Modules/AugmentedSteam";
-import {Background} from "./Modules/Background";
-import {Clipboard} from "./Modules/Clipboard";
-import {CurrencyManager} from "./Modules/CurrencyManager";
-import {DOMHelper} from "./Modules/DOMHelper";
-import {EarlyAccess} from "./Modules/EarlyAccess";
-import {ITAD} from "./Modules/ITAD";
-import {Messenger} from "./Modules/Messenger";
-import {Price} from "./Modules/Price";
-import {Prices} from "./Modules/Prices";
-import {RequestData} from "./Modules/RequestData";
-import {Stats} from "./Modules/Stats";
-import {SteamId, SteamIdDetail} from "./Modules/SteamId";
-import {UpdateHandler} from "./Modules/UpdateHandler";
-import {User} from "./Modules/User";
-import {Viewport} from "./Modules/Viewport";
-
-export {
-    CommunityUtils, ProfileData,
-    Context, ContextType,
-    DynamicStore, Inventory,
-    CallbackFeature, Feature, FeatureManager,
-    ConfirmDialog, HorizontalScroller, ProgressBar, Sortbox,
-    AugmentedSteam,
-    Background,
-    Clipboard,
-    CurrencyManager,
-    DOMHelper,
-    EarlyAccess,
-    ITAD,
-    Messenger,
-    Price,
-    Prices,
-    RequestData,
-    Stats,
-    SteamId,
-    SteamIdDetail,
-    UpdateHandler,
-    User,
-    Viewport
-};
+export {AugmentedSteam} from "./Modules/AugmentedSteam";
+export {Background} from "./Modules/Background";
+export {Clipboard} from "./Modules/Clipboard";
+export {CurrencyManager} from "./Modules/CurrencyManager";
+export {DOMHelper} from "./Modules/DOMHelper";
+export {EarlyAccess} from "./Modules/EarlyAccess";
+export {ITAD} from "./Modules/ITAD";
+export {Messenger} from "./Modules/Messenger";
+export {Price} from "./Modules/Price";
+export {Prices} from "./Modules/Prices";
+export {RequestData} from "./Modules/RequestData";
+export {Stats} from "./Modules/Stats";
+export {SteamId, SteamIdDetail} from "./Modules/SteamId";
+export {UpdateHandler} from "./Modules/UpdateHandler";
+export {User} from "./Modules/User";
+export {Viewport} from "./Modules/Viewport";

--- a/src/js/modulesCore.js
+++ b/src/js/modulesCore.js
@@ -1,36 +1,20 @@
-import {ErrorParser} from "./Core/Errors/ErrorParser";
-import {Errors} from "./Core/Errors/Errors";
-import {HTML} from "./Core/Html/Html";
-import {HTMLParser} from "./Core/Html/HtmlParser";
-import {Language} from "./Core/Localization/Language";
-import {Localization} from "./Core/Localization/Localization";
-import {CookieStorage} from "./Core/Storage/CookieStorage";
-import {LocalStorage} from "./Core/Storage/LocalStorage";
-import {SyncedStorage} from "./Core/Storage/SyncedStorage";
-import {BackgroundSimple} from "./Core/BackgroundSimple";
-import {StringUtils} from "./Core/Utils/StringUtils";
-import {TimeUtils} from "./Core/Utils/TimeUtils";
-import {Debug} from "./Core/Debug";
-import {Downloader} from "./Core/Downloader";
-import {Environment} from "./Core/Environment";
-import {ExtensionResources} from "./Core/ExtensionResources";
-import {GameId} from "./Core/GameId";
-import {Info} from "./Core/Info";
-import {PermissionOptions, Permissions} from "./Core/Permissions";
-import {Version} from "./Core/Version";
-
-export {
-    ErrorParser, Errors,
-    HTML, HTMLParser,
-    Language, Localization,
-    CookieStorage, LocalStorage, SyncedStorage,
-    BackgroundSimple, StringUtils, TimeUtils,
-    Debug,
-    Downloader,
-    Environment,
-    ExtensionResources,
-    GameId,
-    Info,
-    Permissions, PermissionOptions,
-    Version
-};
+export {ErrorParser} from "./Core/Errors/ErrorParser";
+export {Errors} from "./Core/Errors/Errors";
+export {HTML} from "./Core/Html/Html";
+export {HTMLParser} from "./Core/Html/HtmlParser";
+export {Language} from "./Core/Localization/Language";
+export {Localization} from "./Core/Localization/Localization";
+export {CookieStorage} from "./Core/Storage/CookieStorage";
+export {LocalStorage} from "./Core/Storage/LocalStorage";
+export {SyncedStorage} from "./Core/Storage/SyncedStorage";
+export {BackgroundSimple} from "./Core/BackgroundSimple";
+export {StringUtils} from "./Core/Utils/StringUtils";
+export {TimeUtils} from "./Core/Utils/TimeUtils";
+export {Debug} from "./Core/Debug";
+export {Downloader} from "./Core/Downloader";
+export {Environment} from "./Core/Environment";
+export {ExtensionResources} from "./Core/ExtensionResources";
+export {GameId} from "./Core/GameId";
+export {Info} from "./Core/Info";
+export {PermissionOptions, Permissions} from "./Core/Permissions";
+export {Version} from "./Core/Version";


### PR DESCRIPTION
Since the imports aren't used in these files, `export from` syntax can be used to re-export modules, or am I missing something?