### PR TITLE
Fix and improve replaceAccountName

### DIFF
--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -234,17 +234,19 @@ class AugmentedSteam {
     static _replaceAccountName() {
         if (!SyncedStorage.get("replaceaccountname")) { return; }
 
-        const accountNameNode = document.querySelector("#account_pulldown");
-        const accountName = accountNameNode.textContent.trim();
-        const communityName = document.querySelector("#global_header .username").textContent.trim();
+        const logoutNode = document.querySelector("#account_dropdown .persona.online");
+        const accountName = logoutNode.textContent.trim();
+        const communityName = document.querySelector("#account_pulldown").textContent.trim();
 
-        // Present on https://store.steampowered.com/account/history/
-        const pageHeader = document.querySelector("h2.pageheader");
-        if (pageHeader) {
-            pageHeader.textContent = pageHeader.textContent.replace(accountName, communityName);
+        logoutNode.textContent = communityName;
+
+        // Replace page header on account related pages
+        if (location.href.startsWith("https://store.steampowered.com/account")) {
+            const pageHeader = document.querySelector("h2.pageheader");
+            if (pageHeader) {
+                pageHeader.textContent = pageHeader.textContent.replace(new RegExp(accountName, "i"), communityName);
+            }
         }
-
-        accountNameNode.textContent = communityName;
 
         // Don't replace title on user pages that aren't mine
         const isUserPage = /.*(id|profiles)\/.+/g.test(location.pathname);


### PR DESCRIPTION
Should close #930

`#account_pulldown` has been displaying community names for a while now, and the only reference to account names left is in the logout link text and page header, so adjust the feature accordingly.

Also limit the replacement of page header text to account related pages, see https://github.com/tfedor/AugmentedSteam/issues/930#issuecomment-739534849. Account names are also displayed on other pages, like `https://store.steampowered.com/steamaccount/addfunds`, but I believe account related pages cover the majority of cases.