### PR TITLE
Fix "screenshot_open.png"-icon not showing in Firefox

### DIFF
--- a/src/css/augmentedsteam-firefox.css
+++ b/src/css/augmentedsteam-firefox.css
@@ -60,7 +60,7 @@
 }
 
 .es_screenshot_open_btn i {
-  background-image: url('chrome-extension://__MSG_@@extension_id__/img/screenshot_open.png');
+  background-image: url("moz-extension://__MSG_@@extension_id__/img/screenshot_open.png");
 }
 
 .es_regional_icon {


### PR DESCRIPTION
Changed "chrome-extension://" to "moz-extension://" for this.

Was about to create a bug before, but seeing how easy this was to fix, I've created this pull request instead.

As I've already typed the bug report, I guess, why not add it here:

### Expected Behavior

Having a download-icon showing in the screenshot below.

### Actual Behavior

![Screenshot_2020-12-29 Sparen Sie 20% bei Fall Guys Ultimate Knockout auf Steam](https://user-images.githubusercontent.com/9080980/103278775-982a5800-49cc-11eb-87f4-de42036f71a4.png)

### Steps to Reproduce the Problem

  1. Go to any shop-site, e.g. https://store.steampowered.com/app/1097150/Fall_Guys_Ultimate_Knockout/
  2. Look for an image in the shop-gallery at the top of the page
  3. Open this image
  4. The icon is not there in Firefox

This has to do with the image URL for the icon being this:

**chrome-extension://**a1760803-43d5-4425-a810-bcc88155651c/img/screenshot_open.png

Instead of beginning like this in comparison to the fullscreen-icon:

**moz-extension://**a1760803-43d5-4425-a810-bcc88155651c/img/fullscreen-icons.gif

### Specifications

  - Augmented Steam Version: 1.4.8
  - Browser Version : Firefox 84.0.1