### PR TITLE
Improve FDLCCheckboxes

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1965,72 +1965,73 @@ img.astats_icon {
 
 /***************************************
  * Store app pages
- * addDlcCheckboxes()
+ * FDLCCheckboxes
  **************************************/
 #es_selected_btn {
   float: left;
   margin-top: 4px;
   display: none;
 }
-#es_dlc_option_button {
-  float: right;
-  margin-right: 8px;
-  line-height: normal;
-  text-decoration: none;
+#game_area_dlc_expanded + #es_selected_btn {
+  margin-bottom: 10px;
 }
-#es_dlc_option_button:hover {
-  cursor: pointer;
-}
+
 #es_dlc_option_panel {
-  background: url('https://steamcommunity-a.akamaihd.net/public/images/profile/profile_header_bg_texture.jpg');
+  background-color: rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid black;
   height: 28px;
   padding-left: 15px;
-  display: none;
 }
 .es_dlc_option {
   display: inline-block;
-  margin-right: 10px;
+  line-height: 19px;
+  padding: 0 7px;
+  color: #67c1f5;
+  background-color: rgba(103, 193, 245, 0.2);
+  box-shadow: none;
+  margin-right: 2px;
+  border-radius: 2px;
+  cursor: pointer;
   margin-top: 5px;
   font-size: 11px;
-  color: #ffffff;
 }
 .es_dlc_option:hover {
-  text-decoration: underline;
-  cursor: pointer;
+  text-decoration: none;
+  color: #ffffff;
+  background: linear-gradient(135deg, #67c1f5 0%, #417a9b 100%);
 }
 
-/* hide dlc flag due to checkboxes */
 .game_area_dlc_row:hover .ds_flag {
-  display: none;
+  display: none; /* hide dlc flag due to checkboxes (if highlighting is disabled) */
 }
 
-.es_dlc_selection {
-  cursor: default;
+.game_area_dlc_name {
+  margin-left: 23px; /* move title out of the way */
 }
-input[type=checkbox].es_dlc_selection {
+
+label.es_dlc_label {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
+  padding: 4px 11px 1px;
+  top: 0px;
+  left: 1px;
 }
-input[type=checkbox].es_dlc_selection + label {
-  padding-left: 20px;
-  height: 13px;
-  display: inline-block;
-  line-height: 13px;
-  background-repeat: no-repeat;
-  background-position: 0 0;
-  vertical-align: middle;
-  cursor: default;
-  z-index: 99;
+label.es_dlc_label > input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #545454;
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #343434;
+  outline: none;
 }
-input[type=checkbox].es_dlc_selection:checked + label {
-  background-position: 0 -13px;
+label.es_dlc_label > input:checked::after {
+  content: "✔";
+  color: #8bc53f;
+  font-size: 12px;
+  position: absolute;
+  bottom: 3px;
+  left: 14px;
 }
 
 /***************************************

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -1,65 +1,74 @@
-import {ExtensionResources, HTML, Localization} from "../../../../modulesCore";
-import {Feature, User} from "../../../modulesContent";
+import {HTML, Localization} from "../../../../modulesCore";
+import {Feature, Price, User} from "../../../modulesContent";
 
 export default class FDLCCheckboxes extends Feature {
 
     checkPrerequisites() {
-        return document.querySelector(".game_area_dlc_section .game_area_dlc_list");
+        return document.querySelector(".game_area_dlc_section .game_area_dlc_list") !== null;
     }
 
     apply() {
 
-        const dlcs = document.querySelector(".game_area_dlc_section");
-        const imgUrl = ExtensionResources.getURL("img/check_sheet.png");
+        const dlcSection = document.querySelector(".game_area_dlc_section");
+        const selectedDlcs = new Map();
 
-        for (const dlc of dlcs.querySelectorAll(".game_area_dlc_row")) {
-            if (dlc.querySelector("input")) {
-                const value = dlc.querySelector("input").value;
+        for (const dlcRow of dlcSection.querySelectorAll(".game_area_dlc_row")) {
+            const subidNode = dlcRow.querySelector("input[name^=subid]");
+            if (!subidNode) { continue; }
 
-                HTML.afterBegin(dlc.querySelector(".game_area_dlc_name"),
-                    `<input type="checkbox" class="es_dlc_selection" id="es_select_dlc_${value}" value="${value}">
-                    <label for="es_select_dlc_${value}" style="background-image: url(${imgUrl});"></label>`);
-            } else {
-                dlc.querySelector(".game_area_dlc_name").style.marginLeft = "23px";
-            }
+            const label = document.createElement("label");
+            label.classList.add("es_dlc_label");
+
+            const checkbox = document.createElement("input");
+            checkbox.type = "checkbox";
+            checkbox.classList.add("es_dlc_checkbox");
+
+            checkbox.addEventListener("change", () => {
+                if (checkbox.checked) {
+                    const priceNode = dlcRow.querySelector(".discount_final_price")
+                        || dlcRow.querySelector(".game_area_dlc_price");
+
+                    const price = Price.parseFromString(priceNode.textContent);
+
+                    if (price !== null) {
+                        selectedDlcs.set(subidNode.value, price.value);
+                    }
+                } else {
+                    selectedDlcs.delete(subidNode.value);
+                }
+            });
+
+            label.append(checkbox);
+            dlcRow.prepend(label);
         }
 
-        const expandedNode = dlcs.querySelector("#game_area_dlc_expanded");
+        const html = `<div class="game_purchase_action game_purchase_action_bg" id="es_selected_btn">
+                <div class="game_purchase_price price"></div>
+                <div class="btn_addtocart">
+                    <a class="btn_green_steamui btn_medium">
+                        <span>${Localization.str.add_selected_dlc_to_cart}</span>
+                    </a>
+                </div>
+            </div>`;
+
+        const expandedNode = dlcSection.querySelector("#game_area_dlc_expanded");
         if (expandedNode) {
-            HTML.afterEnd(expandedNode,
-                `<div class="game_purchase_action game_purchase_action_bg" style="margin-bottom: 10px;" id="es_selected_btn">
-                    <div class="btn_addtocart">
-                        <a class="btnv6_green_white_innerfade btn_medium">
-                            <span>${Localization.str.add_selected_dlc_to_cart}</span>
-                        </a>
-                    </div>
-                </div>`);
-
-            HTML.afterEnd(dlcs, '<div style="clear: both;"></div>');
+            HTML.afterEnd(expandedNode, html);
+            HTML.afterEnd(dlcSection, '<div style="clear: both;"></div>');
         } else {
-            HTML.afterEnd(dlcs.querySelector(".gameDlcBlocks"),
-                `<div class="game_purchase_action game_purchase_action_bg" id="es_selected_btn">
-                    <div class="btn_addtocart">
-                        <a class="btnv6_green_white_innerfade btn_medium">
-                            <span>${Localization.str.add_selected_dlc_to_cart}</span>
-                        </a>
-                    </div>
-                </div>`);
+            HTML.afterEnd(dlcSection.querySelector(".gameDlcBlocks"), html);
         }
 
-        const form = document.createElement("form");
-        form.setAttribute("name", "add_selected_dlc_to_cart");
-        form.setAttribute("action", "/cart/");
-        form.setAttribute("method", "POST");
-        form.setAttribute("id", "es_selected_cart");
+        const cartForm = document.createElement("form");
+        cartForm.name = "add_selected_dlc_to_cart";
+        cartForm.action = "/cart/";
+        cartForm.method = "POST";
 
-        const cartBtn = dlcs.querySelector("#es_selected_btn");
-        cartBtn.insertAdjacentElement("beforebegin", form);
-        cartBtn.addEventListener("click", () => {
-            form.submit();
-        });
+        const cartBtn = dlcSection.querySelector("#es_selected_btn");
+        cartBtn.insertAdjacentElement("beforebegin", cartForm);
+        cartBtn.addEventListener("click", () => { cartForm.submit(); });
 
-        HTML.afterEnd(dlcs.querySelector(".gradientbg"),
+        HTML.afterEnd(dlcSection.querySelector(".gradientbg"),
             `<div id="es_dlc_option_panel">
                 <div class="es_dlc_option" id="unowned_dlc_check">${Localization.str.dlc_select.unowned_dlc}</div>
                 <div class="es_dlc_option" id="wl_dlc_check">${Localization.str.dlc_select.wishlisted_dlc}</div>
@@ -68,71 +77,60 @@ export default class FDLCCheckboxes extends Feature {
 
         const change = new Event("change", {"bubbles": true});
 
-        dlcs.querySelector("#unowned_dlc_check").addEventListener("click", () => {
-            const nodes = dlcs.querySelectorAll(".game_area_dlc_row:not(.ds_owned) input:not(:checked)");
+        dlcSection.querySelector("#unowned_dlc_check").addEventListener("click", () => {
+            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row:not(.ds_owned) input:not(:checked)");
             for (const node of nodes) {
                 node.checked = true;
                 node.dispatchEvent(change);
             }
         });
 
-        dlcs.querySelector("#wl_dlc_check").addEventListener("click", () => {
-            const nodes = dlcs.querySelectorAll(".ds_wishlist input:not(:checked)");
+        dlcSection.querySelector("#wl_dlc_check").addEventListener("click", () => {
+            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row.ds_wishlist input:not(:checked)");
             for (const node of nodes) {
                 node.checked = true;
                 node.dispatchEvent(change);
             }
         });
 
-        dlcs.querySelector("#no_dlc_check").addEventListener("click", () => {
-            const nodes = dlcs.querySelectorAll(".game_area_dlc_row input:checked");
+        dlcSection.querySelector("#no_dlc_check").addEventListener("click", () => {
+            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row input:checked");
             for (const node of nodes) {
                 node.checked = false;
                 node.dispatchEvent(change);
             }
         });
 
-        HTML.beforeEnd(dlcs.querySelector(".gradientbg"),
-            `<a id="es_dlc_option_button">${Localization.str.dlc_select.select} ▼</a>`);
+        function createHiddenInput(name, value) {
+            const input = document.createElement("input");
+            input.type = "hidden";
+            input.name = name;
+            input.value = value;
 
-        dlcs.querySelector("#es_dlc_option_button").addEventListener("click", e => {
-            dlcs.querySelector("#es_dlc_option_panel").classList.toggle("esi-shown");
+            return input;
+        }
 
-            e.target.textContent = e.target.textContent.includes("▼")
-                ? `${Localization.str.dlc_select.select} ▲`
-                : `${Localization.str.dlc_select.select} ▼`;
-        });
+        const inputAction = createHiddenInput("action", "add_to_cart");
+        const inputSessionId = createHiddenInput("sessionid", User.sessionId);
 
-        dlcs.addEventListener("change", e => {
-            if (!e.target.classList.contains("es_dlc_selection")) { return; }
+        dlcSection.addEventListener("change", ({target}) => {
+            if (!target.classList.contains("es_dlc_checkbox")) { return; }
 
-            const cartForm = dlcs.querySelector("#es_selected_cart");
             cartForm.innerHTML = "";
-
-            const inputAction = document.createElement("input");
-            inputAction.type = "hidden";
-            inputAction.name = "action";
-            inputAction.value = "add_to_cart";
-
-            const inputSessionId = document.createElement("input");
-            inputSessionId.type = "hidden";
-            inputSessionId.name = "sessionid";
-            inputSessionId.value = User.sessionId;
-
             cartForm.append(inputAction, inputSessionId);
 
-            const nodes = dlcs.querySelectorAll(".es_dlc_selection:checked");
-            for (const node of nodes) {
-
-                const inputSubId = document.createElement("input");
-                inputSubId.type = "hidden";
-                inputSubId.name = "subid[]";
-                inputSubId.value = node.value;
-
-                cartForm.append(inputSubId);
+            let total = 0;
+            for (const [subId, price] of selectedDlcs) {
+                cartForm.append(createHiddenInput("subid[]", subId));
+                total += price;
             }
 
-            cartBtn.style.display = nodes.length > 0 ? "block" : "none";
+            if (total > 0) {
+                cartBtn.querySelector(".game_purchase_price").textContent = new Price(total);
+                cartBtn.style.display = "block";
+            } else {
+                cartBtn.style.display = "none";
+            }
         });
     }
 }


### PR DESCRIPTION
A number of improvements to DLC checkboxes, supersedes #883:

![螢幕擷取畫面 2021-01-05 010757](https://user-images.githubusercontent.com/54083835/103561123-d1037a80-4e6d-11eb-9d2f-1c9e8af30cbe.jpg)

1. Show options panel by default and copied styles from app_tag (avoids an extra click, unecessary imo).
2. Use modifications to the browser's native checkbox styling instead of a custom background, also added some padding to the label to make them easier to select.
3. Show total price of selected DLCs next to purchase button.
4. (TODO) Maybe replace Steam's "Add all DLC" button instead of adding our own? Though this means the button will be hidden initially just like Steam's if there's a "SEE ALL" button.