### PR TITLE
Fix match patterns for badges.js

### DIFF
--- a/config/manifests/manifest_common.json
+++ b/config/manifests/manifest_common.json
@@ -333,11 +333,9 @@
       "matches": [
         "*://steamcommunity.com/id/*/friends",
         "*://steamcommunity.com/id/*/friends/*",
-        "*://steamcommunity.com/id/*/friends#*",
         "*://steamcommunity.com/id/*/friends?*",
         "*://steamcommunity.com/profiles/*/friends",
         "*://steamcommunity.com/profiles/*/friends/*",
-        "*://steamcommunity.com/profiles/*/friends#*",
         "*://steamcommunity.com/profiles/*/friends?*"
       ],
       "js": [
@@ -464,11 +462,9 @@
         "*://steamcommunity.com/profiles/*/friendsthatplay*",
         "*://steamcommunity.com/id/*/friends",
         "*://steamcommunity.com/id/*/friends/*",
-        "*://steamcommunity.com/id/*/friends#*",
         "*://steamcommunity.com/id/*/friends?*",
         "*://steamcommunity.com/profiles/*/friends",
         "*://steamcommunity.com/profiles/*/friends/*",
-        "*://steamcommunity.com/profiles/*/friends#*",
         "*://steamcommunity.com/profiles/*/friends?*",
         "*://steamcommunity.com/id/*/groups",
         "*://steamcommunity.com/id/*/groups/",

--- a/config/manifests/manifest_common.json
+++ b/config/manifests/manifest_common.json
@@ -290,9 +290,13 @@
     {
       "matches": [
         "*://steamcommunity.com/id/*/badges",
+        "*://steamcommunity.com/id/*/badges?sort=*",
         "*://steamcommunity.com/id/*/badges/",
+        "*://steamcommunity.com/id/*/badges/?sort=*",
         "*://steamcommunity.com/profiles/*/badges",
-        "*://steamcommunity.com/profiles/*/badges/"
+        "*://steamcommunity.com/profiles/*/badges?sort=*",
+        "*://steamcommunity.com/profiles/*/badges/",
+        "*://steamcommunity.com/profiles/*/badges/?sort=*"
       ],
       "js": [
         "js/community/badges.js"
@@ -447,9 +451,13 @@
         "*://steamcommunity.com/id/*/edit*",
         "*://steamcommunity.com/profiles/*/edit*",
         "*://steamcommunity.com/id/*/badges",
+        "*://steamcommunity.com/id/*/badges?sort=*",
         "*://steamcommunity.com/id/*/badges/",
+        "*://steamcommunity.com/id/*/badges/?sort=*",
         "*://steamcommunity.com/profiles/*/badges",
+        "*://steamcommunity.com/profiles/*/badges?sort=*",
         "*://steamcommunity.com/profiles/*/badges/",
+        "*://steamcommunity.com/profiles/*/badges/?sort=*",
         "*://steamcommunity.com/id/*/gamecards*",
         "*://steamcommunity.com/profiles/*/gamecards*",
         "*://steamcommunity.com/id/*/friendsthatplay*",


### PR DESCRIPTION
Ensures badges page features still work after selecting a sort option.

Also according to [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#path) the # part is not considered as part of the path, so removed some unecessary match patterns.