### PR TITLE
 Fix missing FInGameStoreLink feature

### DIFF
--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -7,6 +7,7 @@ import FCustomBackground from "./FCustomBackground";
 import FProfileStoreLinks from "./FProfileStoreLinks";
 import FSteamRep from "./FSteamRep";
 import FProfileDropdownOptions from "./FProfileDropdownOptions";
+import FInGameStoreLink from "./FInGameStoreLink";
 import FCustomStyle from "./FCustomStyle";
 import FTwitchShowcase from "./FTwitchShowcase";
 import FChatDropdownOptions from "./FChatDropdownOptions";
@@ -45,6 +46,7 @@ export class CProfileHome extends CCommunityBase {
             FProfileStoreLinks,
             FSteamRep,
             FProfileDropdownOptions,
+            FInGameStoreLink,
             FCustomStyle,
             FTwitchShowcase,
             FChatDropdownOptions,


### PR DESCRIPTION
The appid info is located within the deprecated report abuse modal that could be removed at any time. May be worth investigating if there're other ways to get this info.