### PR TITLE
Fix wishlist callback features on wishlists with few items

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/CWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/CWishlist.js
@@ -36,6 +36,9 @@ export class CWishlist extends CStoreBaseCallback {
             this.myWishlist = false;
         }
 
+        // Cache wishlist rows that have rendered already
+        this.renderedWishlistRows = document.querySelectorAll(".wishlist_row");
+
         this._registerObserver();
     }
 

--- a/src/js/Content/Features/Store/Wishlist/FWishlistITADPrices.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistITADPrices.js
@@ -1,7 +1,5 @@
-
 import {SyncedStorage} from "../../../../modulesCore";
-import {CallbackFeature} from "../../../Modules/Feature/CallbackFeature";
-import {Prices} from "../../../Modules/Prices";
+import {CallbackFeature, Prices} from "../../../modulesContent";
 import {Page} from "../../Page";
 
 export default class FWishlistITADPrices extends CallbackFeature {
@@ -51,6 +49,8 @@ export default class FWishlistITADPrices extends CallbackFeature {
             };
             /* eslint-enable no-undef */
         });
+
+        this.callback(this.context.renderedWishlistRows);
     }
 
     callback(nodes) {

--- a/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
+++ b/src/js/Content/Features/Store/Wishlist/FWishlistUserNotes.js
@@ -26,6 +26,8 @@ export default class FWishlistUserNotes extends CallbackFeature {
                 }
             );
         });
+
+        this.callback(this.context.renderedWishlistRows);
     }
 
     callback(nodes) {


### PR DESCRIPTION
See https://github.com/tfedor/AugmentedSteam/issues/953#issuecomment-756909140. The problem is the wishlist may have finised rendering before `_registerObserver()` is called, especially if there're only a few items.

Tested and seems to work, but I'm not sure if it's ideal, since new callback features added in the future will also need to have this fix.