### PR TITLE
FInventoryMarketHelper: Simplify addQuickSellOptions

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -716,6 +716,20 @@ img.astats_icon {
   display: inline-table; /** https://github.com/jshackles/Enhanced_Steam/pull/1624 */
 }
 
+/***************************************
+ * User Inventory
+ * Quicksell/instantsell action buttons
+ **************************************/
+.item_market_actions {
+  display: flex !important;
+  flex-direction: column;
+}
+.item_market_action_button {
+  margin-bottom: 4px;
+  overflow: hidden;
+  width: max-content;
+}
+
 /**************************************
  * Apps page, workshop items
  * media_slider_expander()
@@ -2167,16 +2181,6 @@ img.astats_icon {
 
 .esi_ach_unlocked + .esi_ach_locked {
   margin-top: 72px;
-}
-
-/* market action buttons */
-.item_market_actions {
-  display: flex;
-  flex-direction: column;
-}
-.item_market_action_button {
-  margin-bottom: 4px;
-  overflow: hidden;
 }
 
 /* hide Steam's option on "All Games" page */

--- a/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
+++ b/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
@@ -25,6 +25,11 @@ export default class FInventoryMarketHelper extends Feature {
                     );
                 }
 
+                // https://github.com/SteamDatabase/SteamTracking/blob/f26cfc1ec42b8a0c27ca11f4343edbd8dd293255/steamcommunity.com/public/javascript/economy_v2.js#L4468
+                const publisherFee = (typeof g_ActiveInventory.selectedItem.description.market_fee !== "undefined" && g_ActiveInventory.selectedItem.description.market_fee !== null)
+                    ? g_ActiveInventory.selectedItem.market_fee
+                    : g_rgWalletInfo.wallet_publisher_fee_percent_default;
+
                 window.Messenger.postMessage("sendMessage", [
                     iActiveSelectView,
                     g_ActiveInventory.selectedItem.description.marketable,
@@ -35,6 +40,7 @@ export default class FInventoryMarketHelper extends Feature {
                     g_sessionID,
                     g_ActiveInventory.selectedItem.contextid,
                     g_rgWalletInfo.wallet_currency,
+                    publisherFee,
                     g_ActiveInventory.m_owner.strSteamId,
                     g_ActiveInventory.selectedItem.description.market_marketable_restriction,
                     market_expired
@@ -44,39 +50,6 @@ export default class FInventoryMarketHelper extends Feature {
         });
 
         Messenger.addMessageListener("sendMessage", info => { this._inventoryMarketHelper(info); });
-
-        Messenger.addMessageListener("sendFee", async({
-            feeInfo,
-            "sessionID": sessionId,
-            "global_id": globalId,
-            "contextID": contextId,
-            "assetID": assetId,
-        }) => {
-            const sellPrice = feeInfo.amount - feeInfo.fees;
-            const formData = new FormData();
-            formData.append("sessionid", sessionId);
-            formData.append("appid", globalId);
-            formData.append("contextid", contextId);
-            formData.append("assetid", assetId);
-            formData.append("amount", 1);
-            formData.append("price", sellPrice);
-
-            /*
-             * TODO test what we need to send in request, this is original:
-             * mode: "cors", // CORS to cover requests sent from http://steamcommunity.com
-             * credentials: "include",
-             * headers: { origin: window.location.origin },
-             * referrer: window.location.origin + window.location.pathname
-             */
-
-            await RequestData.post("https://steamcommunity.com/market/sellitem/", formData);
-
-            document.querySelector(`#es_instantsell${assetId}`).parentNode.style.display = "none";
-
-            const node = document.querySelector(`[id="${globalId}_${contextId}_${assetId}"]`);
-            node.classList.add("btn_disabled", "activeInfo");
-            node.style.pointerEvents = "none";
-        });
     }
 
     _inventoryMarketHelper([
@@ -89,6 +62,7 @@ export default class FInventoryMarketHelper extends Feature {
         sessionId,
         contextId,
         walletCurrency,
+        publisherFee,
         ownerSteamId,
         restriction,
         expired
@@ -108,7 +82,6 @@ export default class FInventoryMarketHelper extends Feature {
         const thisItem = document.querySelector(`[id="${_globalId}_${_contextId}_${assetId}"]`);
         const itemActions = document.querySelector(`#iteminfo${item}_item_actions`);
         const marketActions = document.querySelector(`#iteminfo${item}_item_market_actions`);
-        marketActions.style.overflow = "hidden";
 
         // Set as background option
         if (ownsInventory) {
@@ -130,16 +103,24 @@ export default class FInventoryMarketHelper extends Feature {
 
             this._addOneClickGemsOption(item, appid, assetId);
 
-            this._addQuickSellOptions(
-                marketActions,
-                thisItem,
-                _marketable,
-                _contextId,
-                _globalId,
-                assetId,
-                sessionId,
-                walletCurrency
-            );
+            /*
+             * 753 is the appid for "Steam" in the Steam Inventory
+             * 6 is the context used for "Community Items"; backgrounds, emoticons and trading cards
+             * TODO Support non-Steam items
+             */
+            if (_marketable && _contextId === 6 && _globalId === 753) {
+                this._addQuickSellOptions(
+                    item,
+                    thisItem,
+                    marketActions,
+                    _contextId,
+                    _globalId,
+                    assetId,
+                    sessionId,
+                    walletCurrency,
+                    publisherFee
+                );
+            }
         }
 
         /*
@@ -322,151 +303,139 @@ export default class FInventoryMarketHelper extends Feature {
         });
     }
 
-    async _addQuickSellOptions(marketActions, thisItem, marketable, contextId, globalId, assetId, sessionId, walletCurrency) {
+    async _addQuickSellOptions(item, thisItem, marketActions, contextId, globalId, assetId, sessionId, walletCurrency, publisherFee) {
         if (!SyncedStorage.get("quickinv")) { return; }
-        if (!marketable) { return; }
-        if (contextId !== 6 || globalId !== 753) { return; }
 
-        /*
-         * 753 is the appid for "Steam" in the Steam Inventory
-         * 6 is the context used for "Community Items"; backgrounds, emoticons and trading cards
-         */
+        const diff = SyncedStorage.get("quickinv_diff");
 
-        if (!thisItem.classList.contains("es-loading")) {
-            const url = marketActions.querySelector("a").href;
+        // marketActions' innerHTML is cleared on item selection, so the links HTML has to be re-inserted
+        HTML.beforeEnd(marketActions,
+            this._makeMarketButton(`es_quicksell${item}`, Localization.str.quick_sell_desc.replace("__modifier__", diff))
+            + this._makeMarketButton(`es_instantsell${item}`, Localization.str.instant_sell_desc));
 
+        Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
+
+        // Check if price is stored in data
+        if (!thisItem.dataset.priceLow) {
+
+            if (thisItem.classList.contains("es-loading")) { return; }
             thisItem.classList.add("es-loading");
 
-            // Add the links with no data, so we can bind actions to them, we add the data later
-            const diff = SyncedStorage.get("quickinv_diff");
-            HTML.beforeEnd(marketActions, this._makeMarketButton(`es_quicksell${assetId}`, Localization.str.quick_sell_desc.replace("__modifier__", diff)));
-            HTML.beforeEnd(marketActions, this._makeMarketButton(`es_instantsell${assetId}`, Localization.str.instant_sell_desc));
+            thisItem.dataset.priceLow = "nodata";
+            thisItem.dataset.priceHigh = "nodata";
 
-            Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
+            // Get item_nameid of selected item, which can only be found on the item's marketlistings page
+            const result = await RequestData.getHttp(marketActions.querySelector("a").href);
 
-            // Check if price is stored in data
-            if (thisItem.classList.contains("es-price-loaded")) {
-                const priceHighValue = thisItem.dataset.priceHigh;
-                const priceLowValue = thisItem.dataset.priceLow;
+            const m = result.match(/Market_LoadOrderSpread\( (\d+) \)/);
 
-                this._updateMarketButtons(assetId, priceHighValue, priceLowValue, walletCurrency);
-            } else {
-                const result = await RequestData.getHttp(url);
+            if (m) {
+                const data = await RequestData.getJson(`https://steamcommunity.com/market/itemordershistogram?language=english&currency=${walletCurrency}&item_nameid=${m[1]}`);
 
-                const m = result.match(/Market_LoadOrderSpread\( (\d+) \)/);
+                if (data && data.success) {
 
-                if (m) {
-                    const marketId = m[1];
-
-                    const marketUrl = `https://steamcommunity.com/market/itemordershistogram?language=english&currency=${walletCurrency}&item_nameid=${marketId}`;
-                    const market = await RequestData.getJson(marketUrl);
-
-                    let priceHigh = parseFloat(market.lowest_sell_order / 100) + parseFloat(diff);
-                    const priceLow = market.highest_buy_order / 100;
-
-                    // priceHigh.currency == priceLow.currency == Currency.customCurrency, the arithmetic here is in walletCurrency
-
-                    if (priceHigh < 0.03) { priceHigh = 0.03; }
-
-                    // Store prices as data
-                    if (priceHigh > priceLow) {
-                        thisItem.dataset.priceHigh = priceHigh;
-                    }
-                    if (market.highest_buy_order) {
-                        thisItem.dataset.priceLow = priceLow;
+                    if (data.highest_buy_order) {
+                        thisItem.dataset.priceLow = data.highest_buy_order;
                     }
 
-                    // Fixes multiple buttons
-                    if (document.querySelector(".item.activeInfo") === thisItem) {
-                        this._updateMarketButtons(assetId, priceHigh, priceLow, walletCurrency);
-                    }
+                    if (data.lowest_sell_order) {
+                        let priceHigh = parseFloat(data.lowest_sell_order / 100) + parseFloat(diff);
+                        if (priceHigh < 0.03) {
+                            priceHigh = 0.03;
+                        }
 
-                    thisItem.classList.add("es-price-loaded");
+                        thisItem.dataset.priceHigh = priceHigh.toFixed(2) * 100;
+                    }
                 }
             }
 
-            // Loading request either succeeded or failed, no need to flag as still in progress
             thisItem.classList.remove("es-loading");
         }
 
-        // Bind actions to "Quick Sell" and "Instant Sell" buttons
+        // Add data and bind actions to the button if selected item is active
+        if (!thisItem.classList.contains("activeInfo")) { return; }
 
-        const nodes = document.querySelectorAll(`#es_quicksell${assetId}, #es_instantsell${assetId}`);
-        for (const node of nodes) {
-            // eslint-disable-next-line no-loop-func -- Only CalculateFeeAmount is accessed, which isn't an unsafe reference
-            node.addEventListener("click", (e) => {
-                e.preventDefault();
+        const quickSell = document.getElementById(`es_quicksell${item}`);
+        const instantSell = document.getElementById(`es_instantsell${item}`);
 
-                const buttonParent = e.target.closest(".item_market_action_button[data-price]");
-                if (!buttonParent) { return; }
+        const priceHighValue = thisItem.dataset.priceHigh !== "nodata" && thisItem.dataset.priceHigh;
+        const priceLowValue = thisItem.dataset.priceLow !== "nodata" && thisItem.dataset.priceLow;
 
-                const sellPrice = buttonParent.dataset.price * 100;
+        const currencyType = CurrencyManager.currencyNumberToType(walletCurrency);
 
-                const buttons = document.querySelectorAll(`#es_quicksell${assetId}, #es_instantsell${assetId}`);
-                for (const button of buttons) {
-                    button.classList.add("btn_disabled");
-                    button.style.pointerEvents = "none";
-                }
-
-                HTML.inner(
-                    marketActions.querySelector("div"),
-                    `<div class='es_loading' style='min-height: 66px;'><img src='https://steamcommunity-a.akamaihd.net/public/images/login/throbber.gif'><span>${Localization.str.selling}</div>`
-                );
-
-                Page.runInPageContext((sellPrice, sessionID, globalId, contextID, assetID) => {
-                    window.Messenger.postMessage("sendFee",
-                        {
-                            "feeInfo": window.SteamFacade.calculateFeeAmount(sellPrice, 0.10),
-                            sessionID,
-                            "global_id": globalId,
-                            contextID,
-                            assetID,
-                        });
-                },
-                [
-                    sellPrice,
-                    sessionId,
-                    globalId,
-                    contextId,
-                    assetId,
-                ]);
-            });
-        }
-    }
-
-    _makeMarketButton(id, tooltip) {
-        return `<a class="item_market_action_button item_market_action_button_green" id="${id}" data-tooltip-text="${tooltip}" style="display:none">
-                    <span class="item_market_action_button_edge item_market_action_button_left"></span>
-                    <span class="item_market_action_button_contents"></span>
-                    <span class="item_market_action_button_edge item_market_action_button_right"></span>
-                </a>`;
-    }
-
-    _updateMarketButtons(assetId, priceHighValue, priceLowValue, walletCurrency) {
-        const quickSell = document.getElementById(`es_quicksell${assetId}`);
-        const instantSell = document.getElementById(`es_instantsell${assetId}`);
-
-        // Add Quick Sell button
-        if (quickSell && priceHighValue && priceHighValue > priceLowValue) {
+        // Show Quick Sell button
+        if (priceHighValue && priceLowValue && priceHighValue > priceLowValue) {
             quickSell.dataset.price = priceHighValue;
             quickSell.querySelector(".item_market_action_button_contents").textContent
                 = Localization.str.quick_sell.replace(
                     "__amount__",
-                    new Price(priceHighValue, CurrencyManager.currencyNumberToType(walletCurrency))
+                    new Price(priceHighValue / 100, currencyType)
                 );
             quickSell.style.display = "block";
         }
 
-        // Add Instant Sell button
-        if (instantSell && priceLowValue) {
+        // Show Instant Sell button
+        if (priceLowValue) {
             instantSell.dataset.price = priceLowValue;
             instantSell.querySelector(".item_market_action_button_contents").textContent
                 = Localization.str.instant_sell.replace(
                     "__amount__",
-                    new Price(priceLowValue, CurrencyManager.currencyNumberToType(walletCurrency))
+                    new Price(priceLowValue / 100, currencyType)
                 );
             instantSell.style.display = "block";
         }
+
+        async function clickHandler(e) {
+            e.preventDefault();
+
+            const buttonParent = e.target.closest(".item_market_action_button[data-price]");
+            if (!buttonParent) { return; }
+
+            for (const button of [quickSell, instantSell]) {
+                button.classList.add("btn_disabled");
+                button.style.pointerEvents = "none";
+            }
+
+            HTML.inner(marketActions.querySelector("div"),
+                `<div class="es_loading" style="min-height: 66px;">
+                    <img src="//steamcommunity-a.akamaihd.net/public/images/login/throbber.gif">
+                    <span>${Localization.str.selling}</span>
+                </div>`);
+
+            const feeInfo = await Page.runInPageContext((price, fee) => {
+                return window.SteamFacade.calculateFeeAmount(price, fee);
+            }, [buttonParent.dataset.price, publisherFee], true);
+
+            const sellPrice = feeInfo.amount - feeInfo.fees;
+
+            const formData = new FormData();
+            formData.append("sessionid", sessionId);
+            formData.append("appid", globalId);
+            formData.append("contextid", contextId);
+            formData.append("assetid", assetId);
+            formData.append("amount", 1);
+            formData.append("price", sellPrice);
+
+            await RequestData.post("https://steamcommunity.com/market/sellitem/", formData);
+
+            marketActions.style.display = "none";
+            document.getElementById(`iteminfo${item}_item_scrap_actions`).style.display = "none";
+
+            thisItem.classList.add("btn_disabled", "activeInfo");
+            thisItem.style.pointerEvents = "none";
+        }
+
+        quickSell.addEventListener("click", clickHandler);
+        instantSell.addEventListener("click", clickHandler);
+    }
+
+    _makeMarketButton(id, tooltip) {
+        return `<a class="item_market_action_button item_market_action_button_green" id="${id}" data-tooltip-text="${tooltip}" style="display: none;">
+                    <span class="item_market_action_button_edge item_market_action_button_left"></span>
+                    <span class="item_market_action_button_contents"></span>
+                    <span class="item_market_action_button_edge item_market_action_button_right"></span>
+                    <span class="item_market_action_button_preload"></span>
+                </a>`;
     }
 
     async _showMarketOverview(thisItem, marketActions, globalId, hashName, appid, isBooster, walletCurrencyNumber) {

--- a/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
+++ b/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
@@ -365,23 +365,25 @@ export default class FInventoryMarketHelper extends Feature {
 
         // Show Quick Sell button
         if (priceHighValue && priceLowValue && priceHighValue > priceLowValue) {
+
+            Page.runInPageContext((price, type) => window.SteamFacade.vCurrencyFormat(price, type), [priceHighValue, currencyType], true)
+                .then(formattedPrice => {
+                    quickSell.querySelector(".item_market_action_button_contents").textContent
+                        = Localization.str.quick_sell.replace("__amount__", formattedPrice);
+                });
             quickSell.dataset.price = priceHighValue;
-            quickSell.querySelector(".item_market_action_button_contents").textContent
-                = Localization.str.quick_sell.replace(
-                    "__amount__",
-                    new Price(priceHighValue / 100, currencyType)
-                );
             quickSell.style.display = "block";
         }
 
         // Show Instant Sell button
         if (priceLowValue) {
+
+            Page.runInPageContext((price, type) => window.SteamFacade.vCurrencyFormat(price, type), [priceLowValue, currencyType], true)
+                .then(formattedPrice => {
+                    instantSell.querySelector(".item_market_action_button_contents").textContent
+                        = Localization.str.instant_sell.replace("__amount__", formattedPrice);
+                });
             instantSell.dataset.price = priceLowValue;
-            instantSell.querySelector(".item_market_action_button_contents").textContent
-                = Localization.str.instant_sell.replace(
-                    "__amount__",
-                    new Price(priceLowValue / 100, currencyType)
-                );
             instantSell.style.display = "block";
         }
 

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -108,6 +108,10 @@ class SteamFacade {
         return CBoosterCreator.sm_rgBoosterData;
     }
 
+    static vCurrencyFormat(amount, currencyCode) {
+        return v_currencyformat(amount, currencyCode);
+    }
+
     // friends
 
     static toggleManageFriends() {


### PR DESCRIPTION
1. Check market price data before writing to data attributes: the data can be `null` if there're no buy orders or sell orders for that item.
2. Use `${item}` instead of `${assetId}` in the link's id attribute to avoid duplicate id values on the page (if the same item is selected more than twice).
3. Avoid hard-coded `publisherFee` value.
4. Hide the scrap actions container as well after item is sold.
5. Add `important` to our styles to avoid being overwritten by inline styles, also prevent the link width from extending beyond its contents.
6. Improve price display in link label: our `Price` contructor formats prices for the storefront, where decimal values are truncated for currencies that don't use decimals, but it's always possible to use decimal values in the market (due to conversions), so use Steam's `v_currencyformat()` to format prices instead. This prevents issues like this in my currency (NTD):
![螢幕擷取畫面 2021-02-05 194554](https://user-images.githubusercontent.com/54083835/107034549-cc760d00-67f1-11eb-851d-015acaeb4973.jpg)
This is purely a display issue, the actual value stored in data attributes is correct and used as the sell price. Maybe it can be done with some tweaks to `Price` instead?

Tested and there shouldn't be other logic changes.
