### PR TITLE
Fixup FDLCCheckboxes, take 2

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1965,8 +1965,7 @@ img.astats_icon {
 label.es_dlc_label {
   position: absolute;
   padding: 4px 11px 1px;
-  top: 0px;
-  left: 1px;
+  z-index: 999;
 }
 label.es_dlc_label > input {
   -webkit-appearance: none;
@@ -1983,8 +1982,8 @@ label.es_dlc_label > input:checked::after {
   color: #8bc53f;
   font-size: 12px;
   position: absolute;
-  bottom: 3px;
-  left: 14px;
+  bottom: 4px;
+  left: 13px;
 }
 
 /***************************************

--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1958,29 +1958,33 @@ img.astats_icon {
   display: none; /* hide dlc flag due to checkboxes (if highlighting is disabled) */
 }
 
-.es_dlc_selection {
+.game_area_dlc_name {
+  margin-left: 23px; /* move title out of the way */
+}
+
+label.es_dlc_label {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
+  padding: 4px 11px 1px;
+  top: 0px;
+  left: 1px;
 }
-.es_dlc_selection + label {
-  padding-left: 20px;
-  height: 13px;
-  display: inline-block;
-  line-height: 13px;
-  background-repeat: no-repeat;
-  background-position: 0 0;
-  vertical-align: middle;
-  cursor: default;
-  z-index: 99;
+label.es_dlc_label > input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #545454;
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #343434;
+  outline: none;
 }
-.es_dlc_selection:checked + label {
-  background-position: 0 -13px;
+label.es_dlc_label > input:checked::after {
+  content: "✔";
+  color: #8bc53f;
+  font-size: 12px;
+  position: absolute;
+  bottom: 3px;
+  left: 14px;
 }
 
 /***************************************

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -1,4 +1,4 @@
-import {ExtensionResources, HTML, Localization} from "../../../../modulesCore";
+import {HTML, Localization} from "../../../../modulesCore";
 import {Feature, Price, User} from "../../../modulesContent";
 
 export default class FDLCCheckboxes extends Feature {
@@ -17,28 +17,30 @@ export default class FDLCCheckboxes extends Feature {
             const subidNode = dlcRow.querySelector("input[name^=subid]");
             if (!subidNode) { continue; }
 
-            const subid = subidNode.value;
+            const label = document.createElement("label");
+            label.classList.add("es_dlc_label");
 
-            HTML.afterBegin(
-                dlcRow.querySelector(".game_area_dlc_name"),
-                `<input type="checkbox" class="es_dlc_selection" id="es_select_dlc_${subid}" value="${subid}">
-                <label for="es_select_dlc_${subid}" style="background-image: url(${ExtensionResources.getURL("img/check_sheet.png")});"></label>`
-            );
+            const checkbox = document.createElement("input");
+            checkbox.type = "checkbox";
+            checkbox.classList.add("es_dlc_checkbox");
 
-            dlcRow.querySelector("input").addEventListener("change", ({target}) => {
-                if (target.checked) {
+            checkbox.addEventListener("change", () => {
+                if (checkbox.checked) {
                     const priceNode = dlcRow.querySelector(".discount_final_price")
                         || dlcRow.querySelector(".game_area_dlc_price");
 
                     const price = Price.parseFromString(priceNode.textContent);
 
                     if (price !== null) {
-                        selectedDlcs.set(subid, price.value);
+                        selectedDlcs.set(subidNode.value, price.value);
                     }
                 } else {
-                    selectedDlcs.delete(subid);
+                    selectedDlcs.delete(subidNode.value);
                 }
             });
+
+            label.append(checkbox);
+            dlcRow.prepend(label);
         }
 
         const html = `<div class="game_purchase_action game_purchase_action_bg" id="es_selected_btn">
@@ -113,7 +115,7 @@ export default class FDLCCheckboxes extends Feature {
         const inputSessionId = createHiddenInput("sessionid", User.sessionId);
 
         dlcSection.addEventListener("change", ({target}) => {
-            if (!target.classList.contains("es_dlc_selection")) { return; }
+            if (!target.classList.contains("es_dlc_checkbox")) { return; }
 
             cartForm.innerHTML = "";
             cartForm.append(inputAction, inputSessionId);

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -4,7 +4,8 @@ import {Feature, Price, User} from "../../../modulesContent";
 export default class FDLCCheckboxes extends Feature {
 
     checkPrerequisites() {
-        return document.querySelector(".game_area_dlc_section .game_area_dlc_list") !== null;
+        // check if the page has at least one purchasable DLC available
+        return document.querySelector(".game_area_dlc_section .game_area_dlc_list input[name^=subid]") !== null;
     }
 
     apply() {

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -20,6 +20,18 @@ export default class FDLCCheckboxes extends Feature {
             const label = document.createElement("label");
             label.classList.add("es_dlc_label");
 
+            // Add dsinfo to label for use with select/unselect all
+            if (dlcRow.classList.contains("ds_wishlist")) {
+                label.classList.add("es_dlc_wishlist");
+            } else if (dlcRow.classList.contains("ds_owned")) {
+                label.classList.add("es_dlc_owned");
+            }
+
+            // Toggle dsinfo when adding/removing wishlist via ds_options dropdown
+            new MutationObserver(() => {
+                label.classList.toggle("es_dlc_wishlist", dlcRow.classList.contains("ds_wishlist"));
+            }).observe(dlcRow, {"attributeFilter": ["class"]});
+
             const checkbox = document.createElement("input");
             checkbox.type = "checkbox";
             checkbox.classList.add("es_dlc_checkbox");
@@ -40,7 +52,7 @@ export default class FDLCCheckboxes extends Feature {
             });
 
             label.append(checkbox);
-            dlcRow.prepend(label);
+            dlcRow.insertAdjacentElement("beforebegin", label);
         }
 
         const html = `<div class="game_purchase_action game_purchase_action_bg" id="es_selected_btn">
@@ -79,7 +91,7 @@ export default class FDLCCheckboxes extends Feature {
         const change = new Event("change", {"bubbles": true});
 
         dlcSection.querySelector("#unowned_dlc_check").addEventListener("click", () => {
-            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row:not(.ds_owned) input:not(:checked)");
+            const nodes = dlcSection.querySelectorAll(".es_dlc_label:not(.es_dlc_owned) > input:not(:checked)");
             for (const node of nodes) {
                 node.checked = true;
                 node.dispatchEvent(change);
@@ -87,7 +99,7 @@ export default class FDLCCheckboxes extends Feature {
         });
 
         dlcSection.querySelector("#wl_dlc_check").addEventListener("click", () => {
-            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row.ds_wishlist input:not(:checked)");
+            const nodes = dlcSection.querySelectorAll(".es_dlc_label.es_dlc_wishlist > input:not(:checked)");
             for (const node of nodes) {
                 node.checked = true;
                 node.dispatchEvent(change);
@@ -95,7 +107,7 @@ export default class FDLCCheckboxes extends Feature {
         });
 
         dlcSection.querySelector("#no_dlc_check").addEventListener("click", () => {
-            const nodes = dlcSection.querySelectorAll(".game_area_dlc_row input:checked");
+            const nodes = dlcSection.querySelectorAll(".es_dlc_label > input:checked");
             for (const node of nodes) {
                 node.checked = false;
                 node.dispatchEvent(change);

--- a/src/js/Content/Features/Store/App/FDLCCheckboxes.js
+++ b/src/js/Content/Features/Store/App/FDLCCheckboxes.js
@@ -27,11 +27,6 @@ export default class FDLCCheckboxes extends Feature {
                 label.classList.add("es_dlc_owned");
             }
 
-            // Toggle dsinfo when adding/removing wishlist via ds_options dropdown
-            new MutationObserver(() => {
-                label.classList.toggle("es_dlc_wishlist", dlcRow.classList.contains("ds_wishlist"));
-            }).observe(dlcRow, {"attributeFilter": ["class"]});
-
             const checkbox = document.createElement("input");
             checkbox.type = "checkbox";
             checkbox.classList.add("es_dlc_checkbox");
@@ -54,6 +49,14 @@ export default class FDLCCheckboxes extends Feature {
             label.append(checkbox);
             dlcRow.insertAdjacentElement("beforebegin", label);
         }
+
+        // Toggle dsinfo on label when adding/removing wishlist via ds_options dropdown
+        new MutationObserver(mutations => {
+            for (const {target} of mutations) {
+                if (!target.classList.contains("game_area_dlc_row")) { continue; }
+                target.previousElementSibling.classList.toggle("es_dlc_wishlist", target.classList.contains("ds_wishlist"));
+            }
+        }).observe(dlcSection.querySelector(".gameDlcBlocks"), {"subtree": true, "attributeFilter": ["class"]});
 
         const html = `<div class="game_purchase_action game_purchase_action_bg" id="es_selected_btn">
                 <div class="game_purchase_price price"></div>


### PR DESCRIPTION
Actual fixup for #996, replaces the botched attempt at #1006.

Work around invalid `<input>` position by overlapping the `<label>` and `<a>` and giving the label a higher z-index. See the last commit for actual changes.