### PR TITLE
Fix gems option only working for the first 2 selected items

### DIFF
--- a/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
+++ b/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
@@ -283,14 +283,14 @@ export default class FInventoryMarketHelper extends Feature {
     _addOneClickGemsOption(item, appid, assetid) {
         if (!SyncedStorage.get("show1clickgoo")) { return; }
 
-        // scrap link is always present, just hidden if the item cannot be turned into gems
-        const scrapLink = document.querySelector(`#iteminfo${item}_item_scrap_link`);
-        if (scrapLink.classList.contains("esi-show1clickgoo")) { return; }
+        // scrap link is always present, replace the link to avoid attaching multiple listeners
+        const scrapLink = document.getElementById(`iteminfo${item}_item_scrap_link`);
+        const newScrapLink = scrapLink.cloneNode(true);
+        scrapLink.replaceWith(newScrapLink);
 
-        scrapLink.classList.add("esi-show1clickgoo");
-        scrapLink.querySelector("span").textContent = Localization.str.oneclickgoo;
+        newScrapLink.querySelector("span").textContent = Localization.str.oneclickgoo;
 
-        scrapLink.addEventListener("click", e => {
+        newScrapLink.addEventListener("click", e => {
             e.preventDefault();
 
             /*


### PR DESCRIPTION
Regressed by #1034.
I got this mixed up with the quicksell/instantsell stuff. The difference is that quicksell/instantsell HTML is cleared by Steam on item selection, so we can just re-insert HTML and re-attach our listeners, BUT the gems links are always on the page, so added links need to be removed first to avoid having multiple links/attaching multiple listeners. This reverts it to the way it was done before, only we replace the existing link instead of adding our own.