### PR TITLE
Fix marketActions display issue

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -720,14 +720,11 @@ img.astats_icon {
  * User Inventory
  * Quicksell/instantsell action buttons
  **************************************/
-.item_market_actions {
-  display: flex !important;
-  flex-direction: column;
-}
-.item_market_action_button {
+.item_market_actions a.item_market_action_button {
   margin-bottom: 4px;
   overflow: hidden;
   width: max-content;
+  display: block;
 }
 
 /**************************************


### PR DESCRIPTION
Regressed by #1044.
Fix displaying (empty) marketActions section on unmarketable items, and not hiding the section after item had been sold.