### PR TITLE
Simplify setting up tooltips

### DIFF
--- a/src/js/Content/Features/Common/FMediaExpander.js
+++ b/src/js/Content/Features/Common/FMediaExpander.js
@@ -1,6 +1,5 @@
 import {HTML, LocalStorage, Localization, TimeUtils} from "../../../modulesCore";
 import {Feature} from "../../modulesContent";
-import {Page} from "../Page";
 
 export default class FMediaExpander extends Feature {
 
@@ -24,17 +23,9 @@ export default class FMediaExpander extends Feature {
 
         HTML.beforeEnd(selector,
             `<div class="es_slider_toggle btnv6_blue_hoverfade btn_medium">
-                <div data-slider-tooltip="${Localization.str.expand_slider}" class="es_slider_expand"><i class="es_slider_toggle_icon"></i></div>
-                <div data-slider-tooltip="${Localization.str.contract_slider}" class="es_slider_contract"><i class="es_slider_toggle_icon"></i></div>
+                <div data-tooltip-text="${Localization.str.expand_slider}" class="es_slider_expand"><i class="es_slider_toggle_icon"></i></div>
+                <div data-tooltip-text="${Localization.str.contract_slider}" class="es_slider_contract"><i class="es_slider_toggle_icon"></i></div>
             </div>`);
-
-        // Initiate tooltip
-        Page.runInPageContext(() => {
-            window.SteamFacade.vTooltip("[data-slider-tooltip]", {
-                "tooltipClass": "store_tooltip community_tooltip",
-                "dataName": "sliderTooltip"
-            });
-        });
 
         const expandSlider = LocalStorage.get("expand_slider", false);
         if (expandSlider) {

--- a/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
+++ b/src/js/Content/Features/Community/Inventory/FInventoryMarketHelper.js
@@ -313,7 +313,9 @@ export default class FInventoryMarketHelper extends Feature {
             this._makeMarketButton(`es_quicksell${item}`, Localization.str.quick_sell_desc.replace("__modifier__", diff))
             + this._makeMarketButton(`es_instantsell${item}`, Localization.str.instant_sell_desc));
 
-        Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
+        Page.runInPageContext(item => {
+            window.SteamFacade.vTooltip(`#es_quicksell${item}, #es_instantsell${item}`);
+        }, [item]);
 
         // Check if price is stored in data
         if (!thisItem.dataset.priceLow) {

--- a/src/js/Content/Features/Community/Market/FPopularRefreshToggle.js
+++ b/src/js/Content/Features/Community/Market/FPopularRefreshToggle.js
@@ -15,7 +15,7 @@ export default class FPopularRefreshToggle extends Feature {
 
         this._toggleRefresh(LocalStorage.get("popular_refresh", false));
 
-        Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
+        Page.runInPageContext(() => { window.SteamFacade.vTooltip("#es_popular_refresh_toggle"); });
     }
 
     _toggleRefresh(state) {

--- a/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
+++ b/src/js/Content/Features/Community/ProfileEdit/FBackgroundSelection.js
@@ -1,7 +1,6 @@
 import {HTML, Localization, TimeUtils} from "../../../../modulesCore";
 import {Background, DOMHelper, Feature, ProfileData, SteamId} from "../../../modulesContent";
-import Config from "config";
-import {Page} from "../../Page";
+import Config from "../../../../config";
 
 export default class FBackgroundSelection extends Feature {
 
@@ -53,8 +52,6 @@ export default class FBackgroundSelection extends Feature {
             this._imagesNode = document.querySelector(".js-pd-imgs");
 
             this._active = true;
-
-            Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
 
             this._selectedAppid = ProfileData.getBgAppid();
             let selectedGameKey = null;

--- a/src/js/Content/Features/Community/ProfileEdit/FStyleSelection.js
+++ b/src/js/Content/Features/Community/ProfileEdit/FStyleSelection.js
@@ -1,7 +1,6 @@
 import {ExtensionResources, HTML, Localization} from "../../../../modulesCore";
 import {DOMHelper, Feature, ProfileData} from "../../../modulesContent";
 import Config from "../../../../config";
-import {Page} from "../../Page";
 
 export default class FStyleSelection extends Feature {
 
@@ -56,8 +55,6 @@ export default class FStyleSelection extends Feature {
 
             HTML.beforeEnd('[class^="profileeditshell_PageContent_"]', html);
             this._active = true;
-
-            Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
 
             const styleSelectNode = document.querySelector("#es_style");
 

--- a/src/js/Content/Features/Community/ProfileHome/FInGameStoreLink.js
+++ b/src/js/Content/Features/Community/ProfileHome/FInGameStoreLink.js
@@ -1,6 +1,5 @@
 import {HTML, Localization} from "../../../../modulesCore";
 import {Feature, User} from "../../../modulesContent";
-import {Page} from "../../Page";
 
 export default class FInGameStoreLink extends Feature {
 
@@ -16,8 +15,9 @@ export default class FInGameStoreLink extends Feature {
 
         const node = document.querySelector(".profile_in_game_name");
 
-        HTML.inner(node, `<a data-tooltip-html="${Localization.str.view_in_store}" href="//store.steampowered.com/app/${ingameNode.value}" target="_blank">${node.textContent}</a>`);
-
-        Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
+        HTML.inner(node,
+            `<a href="//store.steampowered.com/app/${ingameNode.value}" target="_blank">
+                <span data-tooltip-text="${Localization.str.view_in_store}">${node.textContent}</span>
+            </a>`);
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FSupporterBadges.js
+++ b/src/js/Content/Features/Community/ProfileHome/FSupporterBadges.js
@@ -1,7 +1,6 @@
 import Config from "../../../../config";
 import {HTML, Localization} from "../../../../modulesCore";
 import {Feature, ProfileData} from "../../../modulesContent";
-import {Page} from "../../Page";
 
 export default class FSupporterBadges extends Feature {
 
@@ -38,7 +37,5 @@ export default class FSupporterBadges extends Feature {
         html += "</div></div>";
 
         HTML.afterEnd(".profile_badges", html);
-
-        Page.runInPageContext(() => { window.SteamFacade.setupTooltips(); });
     }
 }

--- a/src/js/Content/Features/Store/App/FNewQueue.js
+++ b/src/js/Content/Features/Store/App/FNewQueue.js
@@ -18,12 +18,7 @@ export default class FNewQueue extends Feature {
 
         Page.runInPageContext(() => {
             const f = window.SteamFacade;
-            f.vTooltip("#es_new_queue", {
-                "tooltipClass": "store_tooltip",
-                "dataName": "tooltipText",
-                "defaultType": "text",
-                "replaceExisting": false
-            });
+            f.vTooltip("#es_new_queue", true);
 
             f.jqOnClick("#es_new_queue", () => {
                 const jq = f.jq;

--- a/src/js/Content/Features/Store/App/FNewQueue.js
+++ b/src/js/Content/Features/Store/App/FNewQueue.js
@@ -18,7 +18,7 @@ export default class FNewQueue extends Feature {
 
         Page.runInPageContext(() => {
             const f = window.SteamFacade;
-            f.vTooltip("#es_new_queue", true);
+            f.vTooltip("#es_new_queue");
 
             f.jqOnClick("#es_new_queue", () => {
                 const jq = f.jq;

--- a/src/js/Content/Features/Store/App/FOpenCritic.js
+++ b/src/js/Content/Features/Store/App/FOpenCritic.js
@@ -1,6 +1,5 @@
 import {ExtensionResources, HTML, Localization, SyncedStorage} from "../../../../modulesCore";
 import {Feature} from "../../../modulesContent";
-import {Page} from "../../Page";
 
 export default class FOpenCritic extends Feature {
 
@@ -66,10 +65,6 @@ export default class FOpenCritic extends Feature {
                         ${html}
                     </div>`);
             }
-
-            Page.runInPageContext(() => {
-                window.SteamFacade.bindTooltips("#game_area_reviews", {"tooltipCSSClass": "store_tooltip"});
-            });
         }
     }
 }

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -86,16 +86,13 @@ class SteamFacade {
 
     // tooltips
 
-    static bindTooltips(selector, rgOptions) {
-        BindTooltips(selector, rgOptions);
-    }
-
-    static setupTooltips(className = "community_tooltip") {
-        return SetupTooltips({"tooltipCSSClass": className});
-    }
-
-    static vTooltip(selector, method) {
-        $J(selector).v_tooltip(method);
+    static vTooltip(selector, isStore = false, isHtml = false) {
+        $J(selector).v_tooltip({
+            "tooltipClass": isStore ? "store_tooltip" : "community_tooltip",
+            "dataName": isHtml ? "tooltipHtml" : "tooltipText",
+            "defaultType": isHtml ? "html" : "text",
+            "replaceExisting": false
+        });
     }
 
     // market

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -86,7 +86,9 @@ class SteamFacade {
 
     // tooltips
 
-    static vTooltip(selector, isStore = false, isHtml = false) {
+    static vTooltip(selector, isHtml = false) {
+        const isStore = window.location.host === "store.steampowered.com";
+
         $J(selector).v_tooltip({
             "tooltipClass": isStore ? "store_tooltip" : "community_tooltip",
             "dataName": isHtml ? "tooltipHtml" : "tooltipText",


### PR DESCRIPTION
Update the wrapper for Steam's `v_tooltip()` method, and remove unnecessary calls to `SetupTooltips()` and `BindTooltips()`.

Steam's `SetupTooltips()` call automatically binds tooltips to future added nodes:
https://github.com/SteamDatabase/SteamTracking/blob/603ef3a3f302f2dddcbc76da98c0b170129e1541/steamcommunity.com/public/shared/javascript/shared_global.js#L4533, as long as the tooltip element is a descendant of the added node (this is due to jQuery's [selector context](https://api.jquery.com/jquery/#selector-context) being implemented with the `find()` method internally).