### PR TITLE
Improve wishlist export dialog display, update button styles

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -1082,16 +1082,14 @@ img.astats_icon {
   color: white;
 }
 
-
 /***************************************
  * Wishlist
+ * FEmptyWishlist/FExportWishlist
  **************************************/
-
 #cart_status_data {
   display: flex;
   align-items: center;
 }
-
 
 .es-wbtn {
   color: #fff;
@@ -1102,7 +1100,6 @@ img.astats_icon {
   padding: 0 25px;
   line-height: 20px;
 }
-
 #es_empty_wishlist {
   margin-right: 3px;
   background-color: #bf5a5a;
@@ -1111,7 +1108,6 @@ img.astats_icon {
   background-color: #ffd1d1;
   color: black;
 }
-
 #es_export_wishlist {
   background-color: #6c94a0;
   margin-right: 15px;
@@ -1121,21 +1117,17 @@ img.astats_icon {
   color: black;
 }
 
-
 .es-wexport {
   margin-bottom: 30px;
 }
-
 .es-wexport__label {
   margin-right: 30px;
   vertical-align: baseline;
 }
-
 .es-wexport__label input[type=radio] {
   position: relative;
   top: 2px;
 }
-
 .es-wexport__input {
   width: 400px;
   color: #b9bfc6;
@@ -1146,10 +1138,15 @@ img.astats_icon {
   padding: 3px 4px;
   border: none;
 }
-
 .es-wexport__symbols {
   margin-top: 2px;
   font-size: 11px;
+}
+.es-wexport__format.es-grayout {
+  opacity: 0.4;
+  pointer-events: none;
+  -webkit-user-select: none;
+  user-select: none;   
 }
 
 /***************************************

--- a/src/js/Content/Features/Store/App/FPackageInfoButton.js
+++ b/src/js/Content/Features/Store/App/FPackageInfoButton.js
@@ -19,7 +19,7 @@ export default class FPackageInfoButton extends Feature {
             HTML.afterBegin(node.querySelector(".game_purchase_action"),
                 `<div class="game_purchase_action_bg">
                     <div class="btn_addtocart btn_packageinfo">
-                        <a class="btnv6_blue_blue_innerfade btn_medium" href="//store.steampowered.com/sub/${subid.value}/">
+                        <a class="btn_blue_steamui btn_medium" href="//store.steampowered.com/sub/${subid.value}/">
                             <span>${Localization.str.package_info}</span>
                         </a>
                     </div>

--- a/src/js/Content/Features/Store/Common/UserNotes.js
+++ b/src/js/Content/Features/Store/Common/UserNotes.js
@@ -14,10 +14,10 @@ export class UserNotes {
                         <textarea name="es_note_input" id="es_note_input" rows="6" cols="12" maxlength="512">__note__</textarea>
                     </div>
                     <div class="es_note_buttons" style="float: right">
-                        <div class="es_note_modal_submit btn_green_white_innerfade btn_medium">
+                        <div class="es_note_modal_submit btn_green_steamui btn_medium">
                             <span>${Localization.str.save}</span>
                         </div>
-                        <div class="es_note_modal_close btn_grey_white_innerfade btn_medium">
+                        <div class="es_note_modal_close btn_grey_steamui btn_medium">
                             <span>${Localization.str.cancel}</span>
                         </div>
                     </div>

--- a/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
+++ b/src/js/Content/Features/Store/RegisterKey/FMultiProductKeys.js
@@ -13,10 +13,10 @@ export default class FMultiProductKeys extends Feature {
                             <textarea name="es_key_input" id="es_key_input" rows="24" cols="12" maxlength="1080">__alreadyentered__</textarea>
                         </div>
                         <div class="es_activate_buttons" style="float: right">
-                            <div class="btn_green_white_innerfade btn_medium es_activate_modal_submit">
+                            <div class="es_activate_modal_submit btn_green_steamui btn_medium">
                                 <span>${Localization.str.activate_products}</span>
                             </div>
-                            <div class="es_activate_modal_close btn_grey_white_innerfade btn_medium">
+                            <div class="es_activate_modal_close btn_grey_steamui btn_medium">
                                 <span>${Localization.str.cancel}</span>
                             </div>
                         </div>

--- a/src/js/Content/Features/Store/Wishlist/FExportWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FExportWishlist.js
@@ -163,8 +163,8 @@ export default class FExportWishlist extends Feature {
 
         const [dlBtn, copyBtn] = document.querySelectorAll(".newmodal_buttons > .btn_medium");
 
-        dlBtn.classList.remove("btn_green_white_innerfade");
-        dlBtn.classList.add("btn_darkblue_white_innerfade");
+        // Update button to new style, remove when not needed
+        copyBtn.classList.replace("btn_darkblue_white_innerfade", "btn_blue_steamui");
 
         // Capture this s.t. the CModal doesn't get destroyed before we can grab this information
         dlBtn.addEventListener("click", () => { exportWishlist(WishlistExporter.method.download); }, true);

--- a/src/js/Content/Features/Store/Wishlist/FExportWishlist.js
+++ b/src/js/Content/Features/Store/Wishlist/FExportWishlist.js
@@ -139,15 +139,14 @@ export default class FExportWishlist extends Feature {
         Page.runInPageContext(exportStr => {
             window.SteamFacade.showConfirmDialog(
                 exportStr.wishlist,
-                `<div id='es_export_form'>
+                `<div id="es_export_form">
                     <div class="es-wexport">
-                    <h2>${exportStr.type}</h2>
-                    <div>
-                        <label class="es-wexport__label"><input type="radio" name="es_wexport_type" value="text" checked> ${exportStr.text}</label>
-                        <label class="es-wexport__label"><input type="radio" name="es_wexport_type" value="json"> JSON</label>
+                        <h2>${exportStr.type}</h2>
+                        <div>
+                            <label class="es-wexport__label"><input type="radio" name="es_wexport_type" value="text" checked> ${exportStr.text}</label>
+                            <label class="es-wexport__label"><input type="radio" name="es_wexport_type" value="json"> JSON</label>
+                        </div>
                     </div>
-                    </div>
-
                     <div class="es-wexport es-wexport__format">
                         <h2>${exportStr.format}</h2>
                         <div>
@@ -173,7 +172,9 @@ export default class FExportWishlist extends Feature {
 
         const format = document.querySelector(".es-wexport__format");
         for (const el of document.getElementsByName("es_wexport_type")) {
-            el.addEventListener("click", e => { format.style.display = e.target.value === "json" ? "none" : ""; });
+            el.addEventListener("click", ({target}) => {
+                format.classList.toggle("es-grayout", target.value === "json");
+            });
         }
     }
 }

--- a/src/js/Content/Modules/Prices.js
+++ b/src/js/Content/Modules/Prices.js
@@ -239,7 +239,7 @@ class Prices {
             purchase += `<div class="game_purchase_action">
                             <div class="game_purchase_action_bg">
                                 <div class="btn_addtocart btn_packageinfo">
-                                    <a class="btnv6_blue_blue_innerfade btn_medium" href="${bundle.details}" target="_blank">
+                                    <a class="btn_blue_steamui btn_medium" href="${bundle.details}" target="_blank">
                                         <span>${Localization.str.bundle.info}</span>
                                     </a>
                                 </div>
@@ -253,7 +253,7 @@ class Prices {
             }
 
             purchase += `<div class="btn_addtocart">
-                            <a class="btnv6_green_white_innerfade btn_medium" href="${bundle.url}" target="_blank">
+                            <a class="btn_green_steamui btn_medium" href="${bundle.url}" target="_blank">
                                 <span>${Localization.str.buy}</span>
                             </a>
                         </div></div></div></div>`;


### PR DESCRIPTION
1. When selecting JSON type, grayout the format area instead of hiding it (which resizes the dialog box).
2. Update button styles for wishlist dialogs and other store features (closes #978) and cleanup html.