### PR TITLE
Relocate customizer button

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -33,34 +33,26 @@
  * Taken from: https://steamstore-a.akamaihd.net/public/css/v6/home.css
  */
 #es_customize_btn {
-  float: right;
-  position: relative;
-  visibility: visible;
+  text-align: left;
 }
-#es_customize_btn .home_customize_btn {
+#es_customize_btn .es_customize_title {
   display: inline-block;
-  background: rgba(103, 193, 245, 0.2);
-  color: #67c1f5;
-  border-radius: 1px;
-  font-size: 11px;
-  line-height: 20px;
   padding: 0 8px;
-  margin-left: 4px;
+  margin: 0 1px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 11px;
   cursor: pointer;
-  position: relative;
-  z-index: 11;
-  margin-right: 2px;
-}
-#es_customize_btn .home_customize_btn:hover {
   color: #ffffff;
-  background: linear-gradient(-60deg, #67c1f5 0%, #417a9b 100%);
 }
-#es_customize_btn .home_customize_btn.active {
-  background: #e3eaef;
-  color: #384959;
+#es_customize_btn .es_customize_title img {
+  vertical-align: text-bottom;
 }
-#es_customize_btn .home_customize_btn.active:hover {
-  background: #e3eaef;
+#es_customize_btn:hover .es_customize_title {
+  text-decoration: none;
+  color: #111111;
+  border-radius: 1px;
+  background: linear-gradient(135deg, #ffffff 0%, #919aa3 100%);
 }
 #es_customize_btn .home_viewsettings_popup {
   position: absolute;
@@ -70,12 +62,12 @@
   z-index: 10;
   box-shadow: 0 0 12px #000000;
   background: linear-gradient(to bottom, #e3eaef 5%, #c7d5e0 95%);
-  right: 2px;
+  right: 0px;
   opacity: 0;
   visibility: hidden;
   transition: visibility, opacity 0.2s ease-in-out;
 }
-#es_customize_btn .active + .home_viewsettings_popup {
+#es_customize_btn:hover .home_viewsettings_popup {
   opacity: 1;
   visibility: visible;
 }
@@ -110,15 +102,6 @@
 }
 #es_customize_btn .home_viewsettings_label {
   text-transform: capitalize;
-}
-.es_customize_homepage_ctn {
-  margin-bottom: 5px;
-  margin-top: 3px;
-}
-.es_customize_homepage_ctn::after {
-  content: "";
-  display: block;
-  clear: both;
 }
 
 .es_tabs {

--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -37,7 +37,8 @@
 }
 #es_customize_btn .es_customize_title {
   display: inline-block;
-  padding: 0 8px;
+  padding-right: 3px;
+  padding-left: 8px;
   margin: 0 1px;
   line-height: 20px;
   text-align: center;
@@ -65,11 +66,12 @@
   right: 0px;
   opacity: 0;
   visibility: hidden;
-  transition: visibility, opacity 0.2s ease-in-out;
+  transition: visibility 0s 0.2s, opacity 0.2s ease-in-out;
 }
-#es_customize_btn:hover .home_viewsettings_popup {
+#es_customize_btn.active .home_viewsettings_popup {
   opacity: 1;
   visibility: visible;
+  transition: visibility, opacity 0.2s ease-in-out;
 }
 #es_customize_btn .home_viewsettings_instructions {
   margin-bottom: 12px;

--- a/src/js/Content/Features/Store/Common/FCustomizer.js
+++ b/src/js/Content/Features/Store/Common/FCustomizer.js
@@ -1,9 +1,18 @@
 import {HTML, Localization, SyncedStorage, TimeUtils} from "../../../../modulesCore";
-import {ContextType, DOMHelper, Feature} from "../../../modulesContent";
+import {ContextType, Feature} from "../../../modulesContent";
 
 export default class FCustomizer extends Feature {
 
     apply() {
+
+        HTML.beforeEnd("#cart_status_data",
+            `<div class="store_header_btn_gray store_header_btn" id="es_customize_btn">
+                <div class="es_customize_title">${Localization.str.customize}<img src="//steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded_white.png"></div>
+                <div class="home_viewsettings_popup">
+                    <div class="home_viewsettings_instructions">${Localization.str.apppage_sections}</div>
+                </div>
+            </div>`);
+
         if (this.context.type === ContextType.APP) {
             this._customizeAppPage();
         } else if (this.context.type === ContextType.STORE_FRONT) {
@@ -12,29 +21,6 @@ export default class FCustomizer extends Feature {
     }
 
     _customizeAppPage() {
-
-        const node = DOMHelper.selectLastNode(document, ".purchase_area_spacer");
-        node.style.height = "auto";
-
-        HTML.beforeEnd(node,
-            `<div id="es_customize_btn">
-                <div class="home_btn home_customize_btn">${Localization.str.customize}</div>
-                <div class='home_viewsettings_popup'>
-                    <div class="home_viewsettings_instructions">${Localization.str.apppage_sections}</div>
-                </div>
-            </div>
-            <div style="clear: both;"></div>`);
-
-        document.querySelector("#es_customize_btn").addEventListener("click", e => {
-            e.target.classList.toggle("active");
-        });
-
-        document.body.addEventListener("click", e => {
-            if (e.target.closest("#es_customize_btn")) { return; }
-            const node = document.querySelector("#es_customize_btn .home_customize_btn.active");
-            if (!node) { return; }
-            node.classList.remove("active");
-        });
 
         function getParentEl(selector) {
             const el = document.querySelector(selector);
@@ -67,30 +53,6 @@ export default class FCustomizer extends Feature {
     }
 
     async _customizeFrontPage() {
-
-        // TODO position when takeover link is active (big banner at the top of the front page)
-        HTML.beforeEnd(".home_page_content",
-            `<div class="es_customize_homepage_ctn">
-                <div id="es_customize_btn">
-                    <div class="home_btn home_customize_btn">${Localization.str.customize}</div>
-                    <div class="home_viewsettings_popup">
-                        <div class="home_viewsettings_instructions">${Localization.str.apppage_sections}</div>
-                    </div>
-                </div>
-            </div>`);
-
-        document.querySelector("#es_customize_btn").addEventListener("click", ({target}) => {
-            target.classList.toggle("active");
-        });
-
-        document.body.addEventListener("click", ({target}) => {
-            if (target.closest("#es_customize_btn")) { return; }
-
-            const node = document.querySelector("#es_customize_btn .home_customize_btn.active");
-            if (!node) { return; }
-
-            node.classList.remove("active");
-        });
 
         // TODO Need a more consistent solution here
         await TimeUtils.timer(1000);

--- a/src/js/Content/Features/Store/Common/FCustomizer.js
+++ b/src/js/Content/Features/Store/Common/FCustomizer.js
@@ -5,7 +5,7 @@ export default class FCustomizer extends Feature {
 
     apply() {
 
-        HTML.beforeEnd("#cart_status_data",
+        HTML.afterBegin("#cart_status_data",
             `<div class="store_header_btn_gray store_header_btn" id="es_customize_btn">
                 <div class="es_customize_title">${Localization.str.customize}<img src="//steamstore-a.akamaihd.net/public/images/v6/btn_arrow_down_padded_white.png"></div>
                 <div class="home_viewsettings_popup">

--- a/src/js/Content/Features/Store/Common/FCustomizer.js
+++ b/src/js/Content/Features/Store/Common/FCustomizer.js
@@ -13,6 +13,20 @@ export default class FCustomizer extends Feature {
                 </div>
             </div>`);
 
+        const customizeBtn = document.getElementById("es_customize_btn");
+
+        customizeBtn.addEventListener("click", () => {
+            customizeBtn.classList.toggle("active");
+        });
+
+        customizeBtn.querySelector(".home_viewsettings_popup").addEventListener("click", e => {
+            e.stopPropagation();
+        });
+
+        customizeBtn.addEventListener("mouseleave", () => {
+            customizeBtn.classList.remove("active");
+        });
+
         if (this.context.type === ContextType.APP) {
             this._customizeAppPage();
         } else if (this.context.type === ContextType.STORE_FRONT) {


### PR DESCRIPTION
Proposal to resolve #509.

Move the customizer button to the store controls section above the navigation area, this way we can have a consistent solution for the storefront and app pages. Also changed the popup to show on mouse hover instead of mouse click.

TODO: Use a different color for the button? Right now it's the same as the wishlist link.