### PR TITLE
Improve invite friends to group on friends page

### DIFF
--- a/src/js/Content/Features/Community/Friends/FInviteButton.js
+++ b/src/js/Content/Features/Community/Friends/FInviteButton.js
@@ -4,21 +4,29 @@ import {Page} from "../../Page";
 
 export default class FInviteButton extends Feature {
 
-    checkPrerequisites() {
-        this._params = new URLSearchParams(window.location.search);
-        return this._params.has("invitegid");
-    }
-
     apply() {
-        HTML.afterBegin("#manage_friends > div:nth-child(2)", `<span class="manage_action btnv6_lightblue_blue btn_medium" id="invitetogroup"><span>${Localization.str.invite_to_group}</span></span>`);
 
-        Page.runInPageContext(groupId => {
-            const f = window.SteamFacade;
-            f.toggleManageFriends();
-            f.jqOnClick("#invitetogroup", () => {
-                const friends = f.getCheckedAccounts("#search_results > .selectable.selected:visible");
-                f.inviteUserToGroup(null, groupId, friends);
+        HTML.afterBegin("#manage_friends > div:nth-child(2)",
+            `<span class="manage_action btnv6_lightblue_blue btn_medium" id="invitetogroup">
+                <span>${Localization.str.invite_to_group}</span>
+            </span>`);
+
+        const params = new URLSearchParams(window.location.search);
+
+        if (params.has("invitegid")) {
+            // Invite initiated from group homepage
+            Page.runInPageContext(groupId => {
+                const f = window.SteamFacade;
+                f.toggleManageFriends();
+                f.jqOnClick("#invitetogroup", () => {
+                    const friends = f.getCheckedAccounts("#search_results > .selectable.selected:visible");
+                    f.inviteUserToGroup(null, groupId, friends);
+                });
+            }, [params.get("invitegid")]);
+        } else {
+            document.getElementById("invitetogroup").addEventListener("click", () => {
+                Page.runInPageContext(() => { window.SteamFacade.execFriendAction("group_invite", "friends/all"); });
             });
-        }, [this._params.get("invitegid")]);
+        }
     }
 }

--- a/src/js/Content/Features/Community/Friends/FInviteButton.js
+++ b/src/js/Content/Features/Community/Friends/FInviteButton.js
@@ -4,6 +4,10 @@ import {Page} from "../../Page";
 
 export default class FInviteButton extends Feature {
 
+    checkPrerequisites() {
+        return document.querySelector("#manage_friends_control") !== null;
+    }
+
     apply() {
 
         HTML.afterBegin("#manage_friends > div:nth-child(2)",

--- a/src/js/Content/Modules/SteamFacade.js
+++ b/src/js/Content/Modules/SteamFacade.js
@@ -140,6 +140,10 @@ class SteamFacade {
         return GetCheckedAccounts(selector);
     }
 
+    static execFriendAction(action, navid) {
+        return ExecFriendAction(action, navid);
+    }
+
     static scrollOffsetForceRecalc() {
         CScrollOffsetWatcher.ForceRecalc();
     }


### PR DESCRIPTION
Related to #584.

At the moment inviting friends to group has to be initiated from the group's homepage, which is slightly inconvenient. This restores the (previous?) behaviour of the invite to group button on friends page, which shows a dialogue that lets you select which group to invite selected friends to.