### PR TITLE
Simplify back-to-top button fade in/out effect

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -9,6 +9,7 @@
   justify-content: center;
   z-index: 9999;
   opacity: 0;
+  visibility: hidden;
   box-shadow: 0 0 10px 2px #000000;
   left: 50%;
   bottom: 20px;
@@ -18,7 +19,7 @@
   border-radius: 50%;
   cursor: pointer;
   background: linear-gradient( to bottom, rgba(33,101,138,1) 5%, rgba(23,67,92,1) 95%);
-  transition: opacity 200ms ease-in-out;
+  transition: visibility 0s 200ms, opacity 200ms ease-in-out;
   color: white;
 }
 .es_btt:hover {
@@ -26,6 +27,8 @@
 }
 .es_btt.is-visible {
   opacity: 1;
+  visibility: visible;
+  transition: visibility, opacity 200ms ease-in-out;
 }
 
 /**

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -67,7 +67,6 @@ class AugmentedSteam {
         const btn = document.createElement("div");
         btn.classList.add("es_btt");
         btn.textContent = "▲";
-        btn.style.visibility = "hidden";
 
         document.body.append(btn);
 
@@ -77,19 +76,6 @@ class AugmentedSteam {
                 "left": 0,
                 "behavior": "smooth"
             });
-        });
-
-        // Make button un-/clickable
-        btn.addEventListener("transitionstart", () => {
-            if (btn.style.visibility === "hidden") {
-                btn.style.visibility = "visible";
-            } else {
-
-                // transition: opacity 200ms ease-in-out;
-                setTimeout(() => {
-                    btn.style.visibility = "hidden";
-                }, 200);
-            }
         });
 
         window.addEventListener("scroll", () => {


### PR DESCRIPTION
Set transition-delay on the visibility property to ensure smooth fade out effect, instead of relying on the transtionstart event and a timeout.