### PR TITLE
Remove option "showfakeccwarning"

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -90,7 +90,6 @@
                     <div data-dynamic="show_progressbar"></div>
                     <div data-dynamic="version_show"></div>
                     <div data-dynamic="replaceaccountname"></div>
-                    <div data-dynamic="showfakeccwarning"></div>
                     <div data-dynamic="show_backtotop"></div>
                     <div data-dynamic="disablelinkfilter"></div>
                     <div data-dynamic="send_age_info"></div>

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -92,6 +92,10 @@ class UpdateHandler {
                 SyncedStorage.set("fav_emoticons", emoticons);
             }
         }
+
+        if (oldVersion.isSameOrBefore("2.0.0")) {
+            SyncedStorage.remove("showfakeccwarning");
+        }
     }
 }
 

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -232,7 +232,6 @@ SyncedStorage.defaults = Object.freeze({
     "showwishliststats": true,
     "user_notes": {},
     "replaceaccountname": true,
-    "showfakeccwarning": true,
     "showlanguagewarning": true,
     "showlanguagewarninglanguage": "english",
     "homepage_tab_selection": "remember",

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -4,7 +4,6 @@ export default {
     "show_progressbar": "show_progressbar",
     "version_show": "options.version_show",
     "replaceaccountname": "options.replace_account_name",
-    "showfakeccwarning": "options.show_regionwarning",
     "show_backtotop": "options.show_backtotop",
     "disablelinkfilter": "options.disablelinkfilter",
     "send_age_info": "options.send_age_info",


### PR DESCRIPTION
Closes #899.

This option has been no-op since transferring to AS. Looking at the implementation, I can't seem to find cookie entries called LKGBillingCountry or fakeCC anymore (or maybe I don't meet the conditions?). Anyhow, it should be fine to remove this option for now and consider it later if we get a specific feature request.