### PR TITLE
Remove option "hideaboutlinks"

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -94,7 +94,6 @@
                     <div data-dynamic="disablelinkfilter"></div>
                     <div data-dynamic="send_age_info"></div>
                     <div data-dynamic="openinnewtab"></div>
-                    <div data-dynamic="hideaboutlinks"></div>
                     <div data-dynamic-select="installsteam"></div>
                 </div>
 

--- a/src/js/Content/Modules/AugmentedSteam.js
+++ b/src/js/Content/Modules/AugmentedSteam.js
@@ -165,12 +165,6 @@ class AugmentedSteam {
         }
     }
 
-    static _removeAboutLinks() {
-        if (!SyncedStorage.get("hideaboutlinks")) { return; }
-
-        DOMHelper.remove("#global_header a[href^='https://store.steampowered.com/about/']");
-    }
-
     static _addUsernameSubmenuLinks() {
         const node = document.querySelector(".supernav_container .submenu_username");
 

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -95,6 +95,7 @@ class UpdateHandler {
 
         if (oldVersion.isSameOrBefore("2.0.0")) {
             SyncedStorage.remove("showfakeccwarning");
+            SyncedStorage.remove("hideaboutlinks");
         }
     }
 }

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -223,7 +223,6 @@ SyncedStorage.defaults = Object.freeze({
     "show_itad_button": false,
     "skip_got_steam": false,
 
-    "hideaboutlinks": false,
     "installsteam": "show",
     "openinnewtab": false,
     "keepssachecked": false,

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -8,7 +8,6 @@ export default {
     "disablelinkfilter": "options.disablelinkfilter",
     "send_age_info": "options.send_age_info",
     "openinnewtab": "options.openinnewtab",
-    "hideaboutlinks": "options.hide_about_links",
     "installsteam": [
         "options.install_steam_button",
         [


### PR DESCRIPTION
After the changes in #832, all this option does now is remove the "About" link under the "Store" dropdown in the header, not really worth an option IMO.

![螢幕擷取畫面 2021-03-03 175940](https://user-images.githubusercontent.com/54083835/109807340-ba588480-7c60-11eb-91fb-15ba01774821.jpg)
