### PR TITLE
Add option for showing "excluded from family sharing" notice

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -193,6 +193,7 @@
                     <div data-dynamic="removebroadcasts"></div>
 
                     <h3 data-locale-text="options.store_general_thirdparty">Options for information from 3rd party sites</h3>
+                    <div data-dynamic="exfgls"></div>
                     <div data-dynamic="showmcus"></div>
                     <div data-dynamic="showoc"></div>
                     <div data-dynamic="showhltb"></div>

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -73,7 +73,6 @@ export default {
     "showwishliststats": "options.show_wishlist_stats",
 
     // store app page
-    "removebroadcasts": "options.removebroadcasts",
     "mp4video": "options.mp4video",
     "showsupportinfo": "options.supportinfo",
     "showdrm": "options.drm",
@@ -83,6 +82,8 @@ export default {
     "purchase_dates": "options.purchase_dates",
     "show_badge_progress": "options.show_badge_progress",
     "show_coupon": "options.show_coupon",
+    "removebroadcasts": "options.removebroadcasts",
+    "exfgls": "options.exfgls",
     "showmcus": "options.metacritic",
     "showoc": "options.opencritic",
     "showhltb": "options.hltb",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -491,6 +491,7 @@
         "inventory_market_text": "Show Market price on inventory page",
         "send_age_info": "Automatically send age verification and skip mature content warnings",
         "removebroadcasts": "Completely remove any live broadcast",
+        "exfgls": "Show a notice if app is excluded from Family Sharing",
         "mp4video": "Force videos to be in MP4 format",
         "youtube": "Show YouTube links",
         "twitch": "Show Twitch links",


### PR DESCRIPTION
This feature has a SyncedStorage check, but somehow never had a corresponding option? Since this feature requires fetching storepagedata, maybe it's better to have an option after all.