### PR TITLE
Add option to pin the profile background position

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2490,6 +2490,21 @@ label.es_dlc_label > input:checked::after {
 }
 
 /***************************************
+ * User profiles
+ * FPinnedBackground
+ **************************************/
+.as_profile_static_background {
+  position: fixed;
+  min-width: 100%;
+  min-height: 100%;
+  width: auto;
+  height: auto;
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: auto;
+}
+
+/***************************************
  * addCustomTags() to community guides
  *
  **************************************/

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -276,6 +276,7 @@
                 <div class="section js-section">
                     <h2 data-locale-text="options.profile" class="js-section-head">Profile</h2>
                     <div data-dynamic="show_custom_themes" class="parent_option"></div>
+                    <div data-dynamic="profile_pinned_bg"></div>
                     <div data-dynamic="show_wishlist_link" class="parent_option"></div>
                     <div data-dynamic="show_wishlist_count" class="option--sub js-sub-option" id="wishlist_link_group"></div>
                     <div data-dynamic="showsteamrepapi"></div>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -275,7 +275,7 @@
 
                 <div class="section js-section">
                     <h2 data-locale-text="options.profile" class="js-section-head">Profile</h2>
-                    <div data-dynamic="show_custom_themes" class="parent_option"></div>
+                    <div data-dynamic="show_custom_themes"></div>
                     <div data-dynamic="profile_pinned_bg"></div>
                     <div data-dynamic="show_wishlist_link" class="parent_option"></div>
                     <div data-dynamic="show_wishlist_count" class="option--sub js-sub-option" id="wishlist_link_group"></div>

--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -12,6 +12,7 @@ import FCustomStyle from "./FCustomStyle";
 import FTwitchShowcase from "./FTwitchShowcase";
 import FChatDropdownOptions from "./FChatDropdownOptions";
 import FViewSteamId from "./FViewSteamId";
+import FPinnedBackground from "./FPinnedBackground";
 
 export class CProfileHome extends CCommunityBase {
 
@@ -50,8 +51,13 @@ export class CProfileHome extends CCommunityBase {
             FTwitchShowcase,
             FChatDropdownOptions,
             FViewSteamId,
+            FPinnedBackground,
         ]);
 
         this.isPrivateProfile = document.body.classList.contains("private_profile");
+
+        // FPinnedBackground needs to wait on custom backgrounds (if any) to be fetched and set
+        FPinnedBackground.dependencies = [FCustomBackground];
+        FPinnedBackground.weakDependency = true;
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
@@ -6,18 +6,7 @@ export default class FCustomBackground extends Feature {
         const prevHash = window.location.hash.match(/#previewBackground\/(\d+)\/([a-z0-9.]+)/i);
         if (prevHash) {
             const imgUrl = `//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/${prevHash[1]}/${prevHash[2]}`;
-
-            const testImg = document.createElement("img");
-            testImg.style.display = "none";
-            testImg.src = imgUrl;
-
-            document.body.append(testImg);
-
-            // Make sure the url is for a valid background image
-            testImg.addEventListener("load", () => {
-                this._setProfileBg(imgUrl);
-                testImg.remove();
-            });
+            this._setProfileBg(imgUrl);
 
             return false;
         }

--- a/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
@@ -23,15 +23,21 @@ export default class FCustomBackground extends Feature {
         this._setProfileBg(bg);
     }
 
+    /**
+     * Only sets static backgrounds for now.
+     * TODO Update to support animated backgrounds once the custom backgrounds database
+     * and/or the "view full image" feature on the Market supports them.
+     */
     _setProfileBg(imgUrl) {
         DOMHelper.remove(".profile_animated_background"); // Animated BGs will interfere with static BGs
 
-        document.body.classList.add("has_profile_background");
-
         const profilePage = document.querySelector(".no_header.profile_page");
-        profilePage.classList.add("has_profile_background");
         profilePage.style.backgroundImage = `url(${imgUrl})`;
 
-        profilePage.querySelector(".profile_content").classList.add("has_profile_background");
+        if (!profilePage.classList.contains("has_profile_background")) {
+            for (const node of [document.body, profilePage, profilePage.querySelector(".profile_content")]) {
+                node.classList.add("has_profile_background");
+            }
+        }
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FPinnedBackground.js
+++ b/src/js/Content/Features/Community/ProfileHome/FPinnedBackground.js
@@ -1,0 +1,30 @@
+import {SyncedStorage} from "../../../../modulesCore";
+import {Feature} from "../../../modulesContent";
+
+export default class FPinnedBackground extends Feature {
+
+    checkPrerequisites() {
+        return SyncedStorage.get("profile_pinned_bg");
+    }
+
+    apply() {
+
+        const animatedBgNode = document.querySelector(".profile_animated_background");
+        if (animatedBgNode) {
+            animatedBgNode.style.position = "fixed";
+        } else {
+            /**
+             * For static bgs, add its own element so it can scroll independently to avoid performance issues.
+             * See https://www.fourkitchens.com/blog/article/fix-scrolling-performance-css-will-change-property/
+             */
+            const bgNode = document.createElement("div");
+            bgNode.classList.add("as_profile_static_background");
+
+            // Copy background-image from inline style
+            const profilePage = document.querySelector(".no_header.profile_page");
+            bgNode.style.backgroundImage = profilePage.style.backgroundImage;
+            profilePage.insertAdjacentElement("afterbegin", bgNode);
+            profilePage.style.backgroundImage = "";
+        }
+    }
+}

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -272,6 +272,7 @@ SyncedStorage.defaults = Object.freeze({
     "show1clickgoo": true,
     "show_profile_link_images": "gray",
     "show_custom_themes": true,
+    "profile_pinned_bg": false,
     "profile_steamrepcn": true,
     "profile_steamgifts": true,
     "profile_steamtrades": true,

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -149,6 +149,7 @@ export default {
     "showinvnav": "options.inventory_nav_text",
 
     // profile
+    "profile_pinned_bg": "options.profile_pinned_bg",
     "show_wishlist_link": "options.show_wishlist_link",
     "show_wishlist_count": "options.show_wishlist_count",
     "showsteamrepapi": "options.steamrepapi",

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -149,11 +149,11 @@ export default {
     "showinvnav": "options.inventory_nav_text",
 
     // profile
+    "show_custom_themes": "options.show_custom_themes",
     "profile_pinned_bg": "options.profile_pinned_bg",
     "show_wishlist_link": "options.show_wishlist_link",
     "show_wishlist_count": "options.show_wishlist_count",
     "showsteamrepapi": "options.steamrepapi",
-    "show_custom_themes": "options.show_custom_themes",
     "profile_steamid": "options.profile_steamid",
     "profile_showcase_twitch": "options.profile_showcase_twitch",
     "profile_showcase_own_twitch": "options.profile_showcase_own_twitch",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -522,6 +522,7 @@
         "lowestprice_onwishlist": "Show when hovering over wishlist items",
         "steamrepapi": "Show SteamRep status",
         "profile_steamid": "Show a link to view SteamIDs",
+        "profile_pinned_bg": "Pin the profile background position while scrolling",
         "header": "Header",
         "lowestprice": "Show on app pages",
         "group_events": "Show events on group overview",


### PR DESCRIPTION
Closes #1163.

For static backgrounds, using `background-attachment: fixed` seems to have a negative impact on scrolling performance (googled a bit and I think it's related to the browser having to repaint the image constantly), so add its own element instead.

~~TODO add option~~
~~TODO needs to work with custom backgrounds and background preview~~