### PR TITLE
Remove options to hide owned/ignored items from search/tag pages

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -141,8 +141,6 @@
 
                 <div class="section js-section">
                     <h2 data-locale-text="hide" class="js-section-head">Hide</h2>
-                    <div data-dynamic="hide_owned"></div>
-                    <div data-dynamic="hide_ignored"></div>
                     <div data-dynamic="hidetmsymbols"></div>
                 </div>
 

--- a/src/js/Content/Features/Common/FHighlightsTags.js
+++ b/src/js/Content/Features/Common/FHighlightsTags.js
@@ -118,10 +118,6 @@ export default class FHighlightsTags extends Feature {
                     this.highlightNotInterested(nodeToHighlight);
                 }
             }
-
-            if (node.classList.contains("search_result_row") && !node.querySelector(".search_discount span")) {
-                this.highlightNonDiscounts(nodeToHighlight);
-            }
         }
 
         const storeIds = Array.from(storeIdsMap.keys());
@@ -391,11 +387,6 @@ export default class FHighlightsTags extends Feature {
     // Color the tile for items in inventory
     static highlightInvGuestpass(node) {
         this._highlightItem(node, "inv_guestpass");
-    }
-
-    static highlightNonDiscounts(node) {
-        if (!SyncedStorage.get("highlight_notdiscounted")) { return; }
-        node.style.display = "none";
     }
 
     static highlightOwned(node) {

--- a/src/js/Content/Features/Common/FHighlightsTags.js
+++ b/src/js/Content/Features/Common/FHighlightsTags.js
@@ -129,11 +129,9 @@ export default class FHighlightsTags extends Feature {
 
         const includeDsInfo
             = !hasDsInfo
-            && ((opts.owned && (SyncedStorage.get("highlight_owned") || SyncedStorage.get("tag_owned")
-                || SyncedStorage.get("hide_owned")))
+            && ((opts.owned && (SyncedStorage.get("highlight_owned") || SyncedStorage.get("tag_owned")))
                 || (opts.wishlisted && (SyncedStorage.get("highlight_wishlist") || SyncedStorage.get("tag_wishlist")))
-                || (opts.ignored && (SyncedStorage.get("highlight_notinterested") || SyncedStorage.get("tag_notinterested")
-                || SyncedStorage.get("hide_ignored")))
+                || (opts.ignored && (SyncedStorage.get("highlight_notinterested") || SyncedStorage.get("tag_notinterested")))
             );
 
         const [dsStatus, itadStatus, invStatus] = await Promise.all([
@@ -401,16 +399,10 @@ export default class FHighlightsTags extends Feature {
     }
 
     static highlightOwned(node) {
-        if (SyncedStorage.get("hide_owned") && (node.closest(".search_result_row") || node.closest(".tab_item"))) {
-            node.style.display = "none";
-        }
         this._highlightItem(node, "owned");
     }
 
     static highlightNotInterested(node) {
-        if (SyncedStorage.get("hide_ignored") && (node.closest(".search_result_row") || node.closest(".tab_item"))) {
-            node.style.display = "none";
-        }
         this._highlightItem(node, "notinterested");
     }
 

--- a/src/js/Content/Features/Common/FHighlightsTags.js
+++ b/src/js/Content/Features/Common/FHighlightsTags.js
@@ -115,7 +115,7 @@ export default class FHighlightsTags extends Feature {
                 }
 
                 if (node.querySelector(".ds_ignored_flag") && opts.ignored) {
-                    this.highlightNotInterested(nodeToHighlight);
+                    this.highlightIgnored(nodeToHighlight);
                 }
             }
         }
@@ -153,7 +153,7 @@ export default class FHighlightsTags extends Feature {
                     nodes.forEach(node => { this.highlightWishlist(node); });
                 }
                 if (opts.ignored && dsStatus[storeid].ignored) {
-                    nodes.forEach(node => { this.highlightNotInterested(node); });
+                    nodes.forEach(node => { this.highlightIgnored(node); });
                 }
             }
 
@@ -182,7 +182,7 @@ export default class FHighlightsTags extends Feature {
 
                 // Same as for the ITAD highlights (don't need to check)
                 if (invStatus[trimmedId].coupon) {
-                    nodes.forEach(node => { this.highlightCoupon(node); });
+                    nodes.forEach(node => { this.highlightInvCoupon(node); });
                 }
             }
         }
@@ -371,29 +371,27 @@ export default class FHighlightsTags extends Feature {
         }
     }
 
-    static highlightWishlist(node) {
-        this._highlightItem(node, "wishlist");
-    }
-
-    static highlightCoupon(node) {
-        this._highlightItem(node, "coupon");
-    }
-
-    // Color the tile for items in inventory
-    static highlightInvGift(node) {
-        this._highlightItem(node, "inv_gift");
-    }
-
-    // Color the tile for items in inventory
-    static highlightInvGuestpass(node) {
-        this._highlightItem(node, "inv_guestpass");
-    }
-
     static highlightOwned(node) {
         this._highlightItem(node, "owned");
     }
 
-    static highlightNotInterested(node) {
+    static highlightWishlist(node) {
+        this._highlightItem(node, "wishlist");
+    }
+
+    static highlightInvCoupon(node) {
+        this._highlightItem(node, "coupon");
+    }
+
+    static highlightInvGift(node) {
+        this._highlightItem(node, "inv_gift");
+    }
+
+    static highlightInvGuestpass(node) {
+        this._highlightItem(node, "inv_guestpass");
+    }
+
+    static highlightIgnored(node) {
         this._highlightItem(node, "notinterested");
     }
 

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -97,6 +97,17 @@ class UpdateHandler {
             SyncedStorage.remove("showfakeccwarning");
             SyncedStorage.remove("hideaboutlinks");
         }
+
+        if (oldVersion.isSameOrBefore("2.0.1")) {
+            SyncedStorage.remove("hide_dlcunownedgames");
+            SyncedStorage.remove("hide_wishlist");
+            SyncedStorage.remove("hide_cart");
+            SyncedStorage.remove("hide_notdiscounted");
+            SyncedStorage.remove("hide_mixed");
+            SyncedStorage.remove("hide_negative");
+            SyncedStorage.remove("hide_priceabove");
+            SyncedStorage.remove("priceabove_value");
+        }
     }
 }
 

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -109,6 +109,7 @@ class UpdateHandler {
             SyncedStorage.remove("priceabove_value");
             SyncedStorage.remove("hide_owned");
             SyncedStorage.remove("hide_ignored");
+            SyncedStorage.remove("highlight_notdiscounted");
         }
     }
 }

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -107,6 +107,8 @@ class UpdateHandler {
             SyncedStorage.remove("hide_negative");
             SyncedStorage.remove("hide_priceabove");
             SyncedStorage.remove("priceabove_value");
+            SyncedStorage.remove("hide_owned");
+            SyncedStorage.remove("hide_ignored");
         }
     }
 }

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -138,8 +138,6 @@ SyncedStorage.defaults = Object.freeze({
     "tag_waitlist": false,
     "tag_short": false,
 
-    "hide_owned": false,
-    "hide_ignored": false,
     "hidetmsymbols": false,
 
     "showlowestprice": true,

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -124,7 +124,6 @@ SyncedStorage.defaults = Object.freeze({
     "highlight_inv_guestpass": false,
     "highlight_notinterested": false,
     "highlight_excludef2p": false,
-    "highlight_notdiscounted": false,
     "highlight_collection": true,
     "highlight_waitlist": true,
 

--- a/src/js/Core/Storage/SyncedStorage.js
+++ b/src/js/Core/Storage/SyncedStorage.js
@@ -140,14 +140,6 @@ SyncedStorage.defaults = Object.freeze({
 
     "hide_owned": false,
     "hide_ignored": false,
-    "hide_dlcunownedgames": false,
-    "hide_wishlist": false,
-    "hide_cart": false,
-    "hide_notdiscounted": false,
-    "hide_mixed": false,
-    "hide_negative": false,
-    "hide_priceabove": false,
-    "priceabove_value": "",
     "hidetmsymbols": false,
 
     "showlowestprice": true,

--- a/src/js/Options/Modules/Data/OptionsSetup.js
+++ b/src/js/Options/Modules/Data/OptionsSetup.js
@@ -53,8 +53,6 @@ export default {
     "tag_short": "tag_short",
 
     // hide
-    "hide_owned": "options.hide_owned",
-    "hide_ignored": "options.hide_ignored",
     "hidetmsymbols": "options.hidetmsymbols",
 
     // store homepage


### PR DESCRIPTION
Closes #258.

Hide owned/ignored items is implemented natively on search pages now, and the "Ignore" function on app pages will blur out items on tag pages. These options overlap existing features and can be removed.