### PR TITLE
Fix `hasAchievements` check on app page

### DIFF
--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -139,7 +139,7 @@ export class CApp extends CStore {
     }
 
     hasAchievements() {
-        return document.querySelector("#achievement_block") !== null;
+        return document.querySelector(".communitylink_achievement_images") !== null;
     }
 
     removeFromWishlist() {


### PR DESCRIPTION
Steam decided to use duplicate ids for the points shop items block
![螢幕擷取畫面 2021-06-13 052820](https://user-images.githubusercontent.com/54083835/121789433-76cec880-cc08-11eb-978e-3c2e0e07e7ff.jpg)

so this check now fails on apps that have point shop items, but no achievements, e.g. https://store.steampowered.com/app/322330/Dont_Starve_Together/