### PR TITLE
Remove empty leading div in OpenCritic block

### DIFF
--- a/src/js/Content/Features/Store/App/FOpenCritic.js
+++ b/src/js/Content/Features/Store/App/FOpenCritic.js
@@ -4,11 +4,12 @@ import {Feature} from "../../../modulesContent";
 export default class FOpenCritic extends Feature {
 
     async checkPrerequisites() {
-        if (SyncedStorage.get("showoc")) {
-            const result = await this.context.data;
-            return result && result.oc && result.oc.url;
-        }
-        return false;
+        if (!SyncedStorage.get("showoc")) { return false; }
+
+        const result = await this.context.data;
+        if (!result || !result.oc || !result.oc.url) { return false; }
+
+        return true;
     }
 
     async apply() {
@@ -25,20 +26,18 @@ export default class FOpenCritic extends Feature {
         }
 
         HTML.afterEnd(node,
-            `<div>
-                <div class="block responsive_apppage_reviewblock">
-                    <div id="game_area_opencritic">
-                        <div class="score ${award.toLowerCase()}">${data.score ? data.score : "--"}</div>
-                        <div class="logo"><img src="${ocImg}"></div>
-                        <div class="wordmark">
-                            <div class="metacritic">OpenCritic</div>
-                            <div id="game_area_metalink">${award} - <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=average" target="_blank">${Localization.str.read_reviews}</a>
-                                <img src="https://steamstore-a.akamaihd.net/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
-                            </div>
+            `<div class="block responsive_apppage_reviewblock">
+                <div id="game_area_opencritic">
+                    <div class="score ${award.toLowerCase()}">${data.score ? data.score : "--"}</div>
+                    <div class="logo"><img src="${ocImg}"></div>
+                    <div class="wordmark">
+                        <div class="metacritic">OpenCritic</div>
+                        <div id="game_area_metalink">${award} - <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=average" target="_blank">${Localization.str.read_reviews}</a>
+                            <img src="https://steamstore-a.akamaihd.net/public/images/ico/iconExternalLink.gif" border="0" align="bottom">
                         </div>
                     </div>
-                    <div style="clear: both;"></div>
                 </div>
+                <div style="clear: both;"></div>
             </div>`);
 
         let reviews = "";
@@ -48,11 +47,13 @@ export default class FOpenCritic extends Feature {
         }
 
         if (reviews) {
-            const html
-                = ` <div id="es_opencritic_reviews">
-                        ${reviews}
-                        <div class="chart-footer">${Localization.str.read_more_reviews} <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=reviews" target="_blank">OpenCritic.com</a></div>
-                    </div>`;
+            const html = `<div id="es_opencritic_reviews">
+                ${reviews}
+                <div class="chart-footer">
+                    ${Localization.str.read_more_reviews}
+                    <a href="${data.url}?utm_source=enhanced-steam-itad&utm_medium=reviews" target="_blank">OpenCritic.com</a>
+                </div>
+            </div>`;
 
             // Add data to the review section in the left column, or create one if that block doesn't exist
             const reviewsNode = document.getElementById("game_area_reviews");


### PR DESCRIPTION
Nothing broken, just to match recent Steam changes to the DOM structure of the right column.