### PR TITLE
Added release date filter

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -2938,7 +2938,8 @@ label[for="show_common_games"] {
 .search_results.mixed .as-hide-mixed,
 .search_results.negative .as-hide-negative,
 .search_results .as-reviews-score,
-.search_results .as-reviews-count {
+.search_results .as-reviews-count,
+.search_results .as-release-date {
   height: 0;
   margin: 0;
   border: none;
@@ -2964,11 +2965,19 @@ label[for="show_common_games"] {
   padding: 7.5px 8px !important; /* 7.5px is the (line-height (28px) - font-size (13px)) / 2 */
 }
 
-.as-reviews-count-filter {
+.as-filter {
   margin-top: 10px;
 }
 
-.as-reviews-count-filter__header {
+.as-filter__input[type="date"] {
+  font: 400 10px Arial;
+}
+
+.as-filter__input[type="date"]::-webkit-calendar-picker-indicator {
+  margin-left: -5px;
+}
+
+.as-filter__header {
   margin-left: 8px;
   font-size: 13px;
   font-family: "Motiva Sans", Sans-serif;
@@ -2976,7 +2985,7 @@ label[for="show_common_games"] {
   color: #9fbbcb;
 }
 
-.as-reviews-count-filter__content {
+.as-filter__content {
   display: flex;
   align-items: center;
   padding: 0 12px;
@@ -2984,7 +2993,7 @@ label[for="show_common_games"] {
 }
 
 /* https://github.com/SteamDatabase/SteamTracking/blob/ad1bfe7966cbfc3a8cdff7d0fcc9f3437425b7a8/store.steampowered.com/public/css/v6/search.css#L546 */
-.as-reviews-count-filter__input {
+.as-filter__input {
   min-width: 0;
   background-color: rgba( 0, 0, 0, 0.2 );
   color: #fff;
@@ -2995,7 +3004,7 @@ label[for="show_common_games"] {
   margin: 5px;
 }
 
-.as-reviews-count-filter__input::placeholder {
+.as-filter__input::placeholder {
   text-transform: lowercase;
 }
 

--- a/src/js/Content/Features/Store/Search/FSearchFilters.js
+++ b/src/js/Content/Features/Store/Search/FSearchFilters.js
@@ -1,4 +1,4 @@
-import {HTML, Localization} from "../../../../modulesCore";
+import {HTML, Language, Localization} from "../../../../modulesCore";
 import {EarlyAccess, Feature, Messenger} from "../../../modulesContent";
 import FHighlightsTags from "../../Common/FHighlightsTags";
 import {Page} from "../../Page";
@@ -8,6 +8,7 @@ import {MixedSearchFilter} from "./Filters/MixedSearchFilter";
 import {NegativeSearchFilter} from "./Filters/NegativeSearchFilter";
 import {ReviewsCountSearchFilter} from "./Filters/ReviewsCountSearchFilter";
 import {ReviewsScoreSearchFilter} from "./Filters/ReviewsScoreSearchFilter";
+import {ReleaseDateSearchFilter} from "./Filters/ReleaseDateSearchFilter";
 
 export default class FSearchFilters extends Feature {
 
@@ -20,8 +21,15 @@ export default class FSearchFilters extends Feature {
             NegativeSearchFilter,
             ReviewsScoreSearchFilter,
             ReviewsCountSearchFilter,
-        ].map(Filter => new Filter(this));
+        ];
 
+        // Only support this filter with english dates
+        if (Language.getCurrentSteamLanguage() === "english") {
+            // TODO: Multilang support?
+            this._filters.push(ReleaseDateSearchFilter);
+        }
+        
+        this._filters = this._filters.map(Filter => new Filter(this));
         this._urlParams = {};
 
         for (const filter of this._filters) {

--- a/src/js/Content/Features/Store/Search/Filters/ReleaseDateSearchFilter.js
+++ b/src/js/Content/Features/Store/Search/Filters/ReleaseDateSearchFilter.js
@@ -1,0 +1,118 @@
+import {Localization} from "../../../../../Core/Localization/Localization";
+import {SearchFilter} from "./SearchFilter";
+
+export class ReleaseDateSearchFilter extends SearchFilter {
+
+    constructor(feature) {
+        super("as-release-date", feature);
+
+        this._val = null;
+    }
+
+    get active() {
+        return this._minDate.value || this._maxDate.value;
+    }
+
+    getHTML() {
+
+        return `<div class="as-filter">
+                    <div class="as-filter__header">${Localization.str.search_filters.release_date}</div>
+                    <div class="as-filter__content js-release-date-filter">
+                        <input class="as-filter__input js-release-date-input js-release-date-lower" type="date">
+                        -
+                        <input class="as-filter__input js-release-date-input js-release-date-upper" type="date"">
+                        <input type="hidden" name="as-release-date">
+                    </div>
+                </div>`;
+    }
+
+    setup(params) {
+
+        this._minDate = document.querySelector(".js-release-date-lower");
+        this._maxDate = document.querySelector(".js-release-date-upper");
+
+        for (const input of document.querySelectorAll(".js-release-date-input")) {
+
+            input.addEventListener("change", () => {
+                this._apply();
+
+                const minVal = this._minDate.value;
+                const maxVal = this._maxDate.value;
+                let val = null;
+
+                if ((minVal && Number(minVal) !== 0) || maxVal) {
+                    val = `${minVal}-${maxVal}`;
+                }
+
+                this.value = val;
+            });
+
+            input.addEventListener("keydown", e => {
+                if (e.key === "Enter") {
+
+                    // Prevents unnecessary submitting of the advanced search form
+                    e.preventDefault();
+
+                    input.dispatchEvent(new Event("change"));
+                }
+            });
+        }
+
+        super.setup(params);
+    }
+
+    _setState(params) {
+
+        let lowerDateVal = "";
+        let upperDateVal = "";
+
+        if (params.has("as-release-date")) {
+
+            const val = params.get("as-release-date");
+            const match = val.match(/(^\d+-\d+-\d+){0,1}-(\d+-\d+-\d+){0,1}/);
+
+            this._value = val;
+
+            if (match) {
+                const [, lower, upper] = match;
+                lowerDateVal = lower;
+                upperDateVal = upper;
+            }
+        }
+
+        if (lowerDateVal !== this._minDate.value) {
+            this._minDate.value = lowerDateVal;
+        }
+        if (upperDateVal !== this._maxDate.value) {
+            this._maxDate.value = upperDateVal;
+        }
+    }
+
+    _addRowMetadata(rows = document.querySelectorAll(".search_result_row:not([data-as-release-date])")) {
+
+        for (const row of rows) {
+            let releaseDate = 0;
+            const releasedNode = row.querySelector(".search_released");
+            if (releasedNode) {
+                const date = new Date(releasedNode.innerText.replace(/.|,/g, " ").replace(/(nd|rd|th|st) /g, " "));
+                
+                if (!isNaN(date)) {
+                    releaseDate = date.valueOf();
+                }
+            }
+
+            row.dataset.asReleaseDate = releaseDate;
+        }
+    }
+
+    _apply(rows = document.querySelectorAll(".search_result_row")) {
+
+        const minDate = new Date(this._minDate.value).valueOf();
+        const maxDate = this._maxDate.value === "" ? Infinity : new Date(this._maxDate.value).valueOf();
+
+        for (const row of rows) {
+            const rowDate = Number(row.dataset.asReleaseDate);
+            row.classList.toggle("as-release-date", rowDate < minDate || rowDate > maxDate);
+        }
+    }
+}

--- a/src/js/Content/Features/Store/Search/Filters/ReviewsCountSearchFilter.js
+++ b/src/js/Content/Features/Store/Search/Filters/ReviewsCountSearchFilter.js
@@ -15,12 +15,12 @@ export class ReviewsCountSearchFilter extends SearchFilter {
 
     getHTML() {
 
-        return `<div class="as-reviews-count-filter">
-                    <div class="as-reviews-count-filter__header">${Localization.str.search_filters.reviews_count.count}</div>
-                    <div class="as-reviews-count-filter__content js-reviews-count-filter">
-                        <input class="as-reviews-count-filter__input js-reviews-count-input js-reviews-count-lower" type="number" min="0" step="100" placeholder="${Localization.str.search_filters.reviews_count.min_count}">
+        return `<div class="as-filter">
+                    <div class="as-filter__header">${Localization.str.search_filters.reviews_count.count}</div>
+                    <div class="as-filter__content js-reviews-count-filter">
+                        <input class="as-filter__input js-reviews-count-input js-reviews-count-lower" type="number" min="0" step="100" placeholder="${Localization.str.search_filters.reviews_count.min_count}">
                         -
-                        <input class="as-reviews-count-filter__input js-reviews-count-input js-reviews-count-upper" type="number" min="0" step="100" placeholder="${Localization.str.search_filters.reviews_count.max_count}">
+                        <input class="as-filter__input js-reviews-count-input js-reviews-count-upper" type="number" min="0" step="100" placeholder="${Localization.str.search_filters.reviews_count.max_count}">
                         <input type="hidden" name="as-reviews-count">
                     </div>
                 </div>`;

--- a/src/js/Content/Features/Store/Search/PSearch.js
+++ b/src/js/Content/Features/Store/Search/PSearch.js
@@ -2,4 +2,3 @@ import {StorePage} from "../../StorePage";
 import {CSearch} from "./CSearch";
 
 (new StorePage()).run(CSearch);
-

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -192,6 +192,7 @@
             "min_count": "Min count",
             "max_count": "Max count"
         },
+        "release_date": "Release date:",
         "hide_cart": "Hide items in your Cart",
         "hide_ea": "Hide Early Access items",
         "hide_mixed": "Hide mixed rating items",


### PR DESCRIPTION
Sadly, this only works on English search results for now, as it uses `Date.parse` to parse the release dates, which only supports the English language. Months are often text, so I cannot parse numbers only. Requesting an English release date for all search results would make too many requests. One solution for multi-lang support, I can think of, is using a third party library that supports it. For now, I think this feature is fine to be English only.  

Resolves https://github.com/tfedor/AugmentedSteam/issues/1206