### PR TITLE
Improve "activate keys in selection" context menu action

### DIFF
--- a/src/js/Background/Modules/ContextMenu.js
+++ b/src/js/Background/Modules/ContextMenu.js
@@ -1,6 +1,4 @@
-import {Localization} from "../../Core/Localization/Localization";
-import {SyncedStorage} from "../../Core/Storage/SyncedStorage";
-import {Permissions} from "../../modulesCore";
+import {Localization, Permissions, SyncedStorage} from "../../modulesCore";
 
 class ContextMenu {
 
@@ -23,8 +21,8 @@ class ContextMenu {
     }
 
     static async build() {
-        await Localization;
         await SyncedStorage;
+        await Localization;
 
         for (const option of Object.keys(ContextMenu.queryLinks)) {
             if (!SyncedStorage.get(option)) { continue; }

--- a/src/js/Background/Modules/ContextMenu.js
+++ b/src/js/Background/Modules/ContextMenu.js
@@ -5,25 +5,21 @@ import {Permissions} from "../../modulesCore";
 class ContextMenu {
 
     static onClick(info) {
-        const query = encodeURIComponent(info.selectionText.trim());
         const url = ContextMenu.queryLinks[info.menuItemId];
         if (!url) { return; }
 
+        let query = info.selectionText.trim();
+
         if (info.menuItemId === "context_steam_keys") {
             const steamKeys = query.match(/[A-Z0-9]{5}(-[A-Z0-9]{5}){2}/g);
-            if (!steamKeys || steamKeys.length === 0) {
 
-                // eslint-disable-next-line no-alert -- TODO Find a better way
-                window.alert(Localization.str.options.no_keys_found);
-                return;
+            // Set the query to matched keys if any, otherwise display the selected text anyway
+            if (Array.isArray(steamKeys)) {
+                query = steamKeys.join(",");
             }
-
-            for (const steamKey of steamKeys) {
-                browser.tabs.create({"url": url.replace("__steamkey__", steamKey)});
-            }
-        } else {
-            browser.tabs.create({"url": url.replace("__query__", query)});
         }
+
+        browser.tabs.create({"url": url.replace("__query__", encodeURIComponent(query))});
     }
 
     static async build() {
@@ -63,7 +59,7 @@ ContextMenu.queryLinks = {
     "context_bartervg": "https://barter.vg/search?q=__query__",
     "context_steamdb": "https://steamdb.info/search/?q=__query__",
     "context_steamdb_instant": "https://steamdb.info/instantsearch/?query=__query__",
-    "context_steam_keys": "https://store.steampowered.com/account/registerkey?key=__steamkey__"
+    "context_steam_keys": "https://store.steampowered.com/account/registerkey?key=__query__"
 };
 
 export {ContextMenu};


### PR DESCRIPTION
If there're no valid keys within selection, open a new tab anyway and display a "no keys found" error message. Closes #1228.

![螢幕擷取畫面 2021-08-06 080757](https://user-images.githubusercontent.com/54083835/128437888-eedfac79-7d9f-4b79-ac98-f8178c4364f7.jpg)
