### PR TITLE
Fix null error on collection pages without subscribable items

### DIFF
--- a/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
+++ b/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
@@ -5,12 +5,12 @@ import Workshop from "../Workshop";
 export default class FSubscribeAllDependencies extends Feature {
 
     checkPrerequisites() {
+        if (document.getElementById("SubscribeItemBtn") === null) { return false; }
+
         return User.isSignedIn;
     }
 
     apply() {
-        if (document.getElementById("SubscribeItemBtn") === null) { return; }
-
         document.getElementById("SubscribeItemBtn").addEventListener("click", () => {
 
             if (document.querySelector(".newmodal") === null) { return; }

--- a/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
+++ b/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
@@ -9,6 +9,8 @@ export default class FSubscribeAllDependencies extends Feature {
     }
 
     apply() {
+        if (document.getElementById("SubscribeItemBtn") === null) { return; }
+
         document.getElementById("SubscribeItemBtn").addEventListener("click", () => {
 
             if (document.querySelector(".newmodal") === null) { return; }

--- a/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
+++ b/src/js/Content/Features/Community/SharedFiles/FSubscribeAllDependencies.js
@@ -5,9 +5,7 @@ import Workshop from "../Workshop";
 export default class FSubscribeAllDependencies extends Feature {
 
     checkPrerequisites() {
-        if (document.getElementById("SubscribeItemBtn") === null) { return false; }
-
-        return User.isSignedIn;
+        return document.getElementById("SubscribeItemBtn") !== null && User.isSignedIn;
     }
 
     apply() {


### PR DESCRIPTION
When a user visits a collection page without any subscribable items, the FSubscribeAllDependencies feature crashes due to a null pointer. This is a simple fix for that, to keep the console clear of errors. 

Tested on firefox.

