### PR TITLE
Double height of collection choice section

### DIFF
--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -886,6 +886,9 @@ img.astats_icon {
 .highlight_overflow {
   z-index: 5;
 }
+.collectionChoiceSection {
+  height: 400px;
+}
 /* When browser window is too small hide the side details and the toggle button in Store */
 @media (max-width: 910px) {
   #game_highlights .rightcol {

--- a/src/css/augmentedsteam.css
+++ b/src/css/augmentedsteam.css
@@ -25,6 +25,13 @@
 #modalContent.modal_frame {
   min-width: 720px !important;
 }
+/**
+ * https://github.com/tfedor/AugmentedSteam/issues/1254
+ * Increase height of collection choice section 
+ */
+.collectionChoiceSection {
+  height: 400px;
+}
 
 /* Back To Top button */
 .es_btt {
@@ -885,9 +892,6 @@ img.astats_icon {
 }
 .highlight_overflow {
   z-index: 5;
-}
-.collectionChoiceSection {
-  height: 400px;
 }
 /* When browser window is too small hide the side details and the toggle button in Store */
 @media (max-width: 910px) {


### PR DESCRIPTION
This doubles the height of the item selection box in the collection modification screen. The collection modification screen, normally found at `https://steamcommunity.com/sharedfiles/managecollection/?id=XXXXXXXXXX`, defaults to a height of `200px` on all screen sizes. This PR doubles that to `400px` to improve user experience. 

I tested this on firefox, at various resolutions. I also did a cursory browse of other collection-related pages to ensure that the `.collectionChoiceSection`is only found on this page. 