### PR TITLE
FCommunityProfileLinks: simplify code, stop auto appending "[ID]" to custom links

### DIFF
--- a/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
@@ -72,13 +72,8 @@ export default class FCommunityProfileLinks extends Feature {
         for (const customLink of SyncedStorage.get("profile_custom_link")) {
             if (!customLink.enabled) { continue; }
 
-            let customUrl = customLink.url;
-            if (!customUrl.includes("[ID]")) {
-                customUrl += "[ID]";
-            }
-
             const name = HTML.escape(customLink.name);
-            const link = `//${HTML.escape(customUrl.replace("[ID]", steamId))}`;
+            const link = `//${HTML.escape(customLink.url.replace("[ID]", steamId))}`;
             let icon;
             if (customLink.icon) {
                 icon = `//${HTML.escape(customLink.icon)}`;

--- a/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
@@ -7,12 +7,6 @@ export default class FCommunityProfileLinks extends Feature {
 
         const steamId = SteamId.getSteamId();
 
-        let iconType = "none";
-        const images = SyncedStorage.get("show_profile_link_images");
-        if (images !== "none") {
-            iconType = images === "color" ? "color" : "gray";
-        }
-
         const links = [
             {
                 "id": "steamrep",
@@ -56,7 +50,7 @@ export default class FCommunityProfileLinks extends Feature {
             }
         ];
 
-        // Add "SteamRepCN"
+        // Add SteamRepCN link if language is Chinese
         const language = Language.getCurrentSteamLanguage();
         if ((language === "schinese" || language === "tchinese") && SyncedStorage.get("profile_steamrepcn")) {
             links.push({
@@ -66,19 +60,17 @@ export default class FCommunityProfileLinks extends Feature {
             });
         }
 
-        // Build the links HTML
-        let htmlstr = "";
+        let html = "";
+        let iconType = SyncedStorage.get("show_profile_link_images");
 
-        for (const link of links) {
-            if (!SyncedStorage.get(`profile_${link.id}`)) { continue; }
-            htmlstr += CommunityUtils.makeProfileLink(link.id, link.link, link.name, iconType);
+        for (const {id, link, name} of links) {
+            if (!SyncedStorage.get(`profile_${id}`)) { continue; }
+            html += CommunityUtils.makeProfileLink(id, link, name, iconType);
         }
 
         // custom profile link
         for (const customLink of SyncedStorage.get("profile_custom_link")) {
-            if (!customLink || !customLink.enabled) {
-                continue;
-            }
+            if (!customLink.enabled) { continue; }
 
             let customUrl = customLink.url;
             if (!customUrl.includes("[ID]")) {
@@ -94,17 +86,16 @@ export default class FCommunityProfileLinks extends Feature {
                 iconType = "none";
             }
 
-            htmlstr += CommunityUtils.makeProfileLink("custom", link, name, iconType, icon);
+            html += CommunityUtils.makeProfileLink("custom", link, name, iconType, icon);
         }
 
-        // Insert the links HMTL into the page
-        if (htmlstr) {
+        if (html) {
             const linksNode = document.querySelector(".profile_item_links");
             if (linksNode) {
-                HTML.beforeEnd(linksNode, `${htmlstr}<div style="clear: both;"></div>`);
+                HTML.beforeEnd(linksNode, `${html}<div style="clear: both;"></div>`);
             } else {
                 const rightColNode = document.querySelector(".profile_rightcol");
-                HTML.beforeEnd(rightColNode, `<div class="profile_item_links">${htmlstr}</div>`);
+                HTML.beforeEnd(rightColNode, `<div class="profile_item_links">${html}</div>`);
                 HTML.afterEnd(rightColNode, '<div style="clear: both;"></div>');
             }
         }

--- a/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCommunityProfileLinks.js
@@ -36,7 +36,7 @@ export default class FCommunityProfileLinks extends Feature {
             },
             {
                 "id": "bartervg",
-                "link": `//barter.vg/steam/${steamId}`,
+                "link": `https://barter.vg/steam/${steamId}`,
                 "name": "Barter.vg",
             },
             {
@@ -61,7 +61,7 @@ export default class FCommunityProfileLinks extends Feature {
         if ((language === "schinese" || language === "tchinese") && SyncedStorage.get("profile_steamrepcn")) {
             links.push({
                 "id": "steamrepcn",
-                "link": `//steamrepcn.com/profiles/${steamId}`,
+                "link": `https://steamrepcn.com/profiles/${steamId}`,
                 "name": (language === "schinese" ? "查看信誉记录" : "確認信譽記錄")
             });
         }

--- a/src/js/Content/Modules/UpdateHandler.js
+++ b/src/js/Content/Modules/UpdateHandler.js
@@ -123,6 +123,14 @@ class UpdateHandler {
 
         if (oldVersion.isSameOrBefore("2.1.0")) {
             SyncedStorage.remove("showcomparelinks");
+
+            const links = SyncedStorage.get("profile_custom_link");
+            for (const link of links) {
+                if (link.url && !link.url.includes("[ID]")) {
+                    link.url += "[ID]";
+                }
+            }
+            SyncedStorage.set("profile_custom_link", links);
         }
     }
 }

--- a/src/js/Options/Modules/CustomLinks.js
+++ b/src/js/Options/Modules/CustomLinks.js
@@ -61,14 +61,9 @@ class CustomLinks {
     _create(link) {
         const node = this._template.cloneNode(true);
 
-        let url = link.url;
-        if (url && !url.includes("[ID]")) {
-            url += "[ID]";
-        }
-
         node.querySelector(`[name="${this._type}_custom_enabled"]`).checked = link.enabled;
         node.querySelector(`[name="${this._type}_custom_name"]`).value = link.name;
-        node.querySelector(`[name="${this._type}_custom_url"]`).value = url;
+        node.querySelector(`[name="${this._type}_custom_url"]`).value = link.url;
         node.querySelector(`[name="${this._type}_custom_icon"]`).value = link.icon;
 
         this._container.append(node);


### PR DESCRIPTION
Up until now an "[ID]" gets automatically added to custom links if missing from the URL, but with the addition of custom links on app pages, this requirement seems unnecessary because not all sites query Steam appids. As for custom links on profile pages, if the user wants the same link on every profile, so be it.

On a side note, it's possible to save links without an "[ID]" to storage because it is only checked when the links are rendered on the options page, not when they're saved (the behaviour is the same since it is checked again in the feature), so to be safe I think we need to make sure existing links all have an "[ID]".