### PR TITLE
Fix pack breakdown prices not showing if package info button is enabled

### DIFF
--- a/src/js/Content/Features/Store/App/CApp.js
+++ b/src/js/Content/Features/Store/App/CApp.js
@@ -116,6 +116,10 @@ export class CApp extends CStore {
         // The customizer has to wait on this data to be added in order to find the HTML elements
         FCustomizer.dependencies = [FSteamSpy, FSteamChart, FSurveyData];
         FCustomizer.weakDependency = true;
+
+        // FPackBreakdown skips purchase options with a package info button to avoid false positives
+        FPackageInfoButton.dependencies = [FPackBreakdown];
+        FPackageInfoButton.weakDependency = true;
     }
 
     storePageDataPromise() {


### PR DESCRIPTION
Split out this bugfix from #1189.