### PR TITLE
Fixup LNY2020 theme

### DIFF
--- a/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
+++ b/src/js/Content/Features/Community/ProfileHome/CProfileHome.js
@@ -59,8 +59,11 @@ export class CProfileHome extends CCommunityBase {
 
         FEarlyAccess.show(document.querySelectorAll(".game_info_cap, .showcase_slot:not(.showcase_achievement)"));
 
-        // FPinnedBackground needs to wait on custom backgrounds (if any) to be fetched and set
-        FPinnedBackground.dependencies = [FCustomBackground];
+        // Need to wait on custom background and style (LNY2020 may set the background) to be fetched and set
+        FPinnedBackground.dependencies = [FCustomBackground, FCustomStyle];
         FPinnedBackground.weakDependency = true;
+
+        // Required for LNY2020 to check whether the profile has a (custom) background
+        FCustomStyle.dependencies = [FCustomBackground];
     }
 }

--- a/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomBackground.js
@@ -6,7 +6,7 @@ export default class FCustomBackground extends Feature {
         const prevHash = window.location.hash.match(/#previewBackground\/(\d+)\/([a-z0-9.]+)/i);
         if (prevHash) {
             const imgUrl = `//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/${prevHash[1]}/${prevHash[2]}`;
-            this.setProfileBg(imgUrl);
+            this._setProfileBg(imgUrl);
 
             return false;
         }
@@ -20,7 +20,7 @@ export default class FCustomBackground extends Feature {
         const bg = ProfileData.getBgImgUrl();
         if (!bg) { return; }
 
-        FCustomBackground.setProfileBg(bg);
+        this._setProfileBg(bg);
     }
 
     /**
@@ -28,7 +28,7 @@ export default class FCustomBackground extends Feature {
      * TODO Update to support animated backgrounds once the custom backgrounds database
      * and/or the "view full image" feature on the Market supports them.
      */
-    static setProfileBg(imgUrl) {
+    _setProfileBg(imgUrl) {
         DOMHelper.remove(".profile_animated_background"); // Animated BGs will interfere with static BGs
 
         const profilePage = document.querySelector(".no_header.profile_page");

--- a/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
@@ -105,6 +105,22 @@ export default class FCustomStyle extends Feature {
                 avatarNode.classList.add("golden");
                 HTML.afterBegin(avatarNode, "<div class='goldenAvatarOverlay'></div>");
 
+                // Use the animated BG that comes with this theme if the profile has no BG equipped
+                if (!profilePageNode.classList.contains("has_profile_background")) {
+
+                    HTML.afterBegin(profilePageNode,
+                        `<div class="profile_animated_background">
+                            <video playsinline autoplay muted loop poster="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg">
+                                <source src="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/c146558951b46ade8d64ea8e787980f84d30ec46.webm" type="video/webm">
+                                <source src="//steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/b5c39efda3998e0d2e734e8b7385ecf705ce8cc5.mp4" type="video/mp4">
+                            </video>
+                        </div>`);
+
+                    for (const node of [document.body, profilePageNode, profilePageNode.querySelector(".profile_content")]) {
+                        node.classList.add("has_profile_background");
+                    }
+                }
+
                 break;
             }
             case "goldenprofile": {

--- a/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
+++ b/src/js/Content/Features/Community/ProfileHome/FCustomStyle.js
@@ -1,6 +1,5 @@
 import {ExtensionResources, HTML, SyncedStorage} from "../../../../modulesCore";
 import {DOMHelper, Feature, ProfileData} from "../../../modulesContent";
-import FCustomBackground from "./FCustomBackground";
 
 export default class FCustomStyle extends Feature {
 
@@ -106,10 +105,6 @@ export default class FCustomStyle extends Feature {
                 avatarNode.classList.add("golden");
                 HTML.afterBegin(avatarNode, "<div class='goldenAvatarOverlay'></div>");
 
-                if (!profilePageNode.classList.contains("has_profile_background")) {
-                    FCustomBackground.setProfileBg("https://steamcdn-a.akamaihd.net/steamcommunity/public/images/items/1223590/daa4b34582ed6cab1327f247be8d03d92ae8aaaa.jpg");
-                }
-
                 break;
             }
             case "goldenprofile": {
@@ -173,6 +168,3 @@ export default class FCustomStyle extends Feature {
         }
     }
 }
-
-// Required for LNY2020 to check whether the profile has a (custom) background
-FCustomStyle.dependencies = [FCustomBackground];


### PR DESCRIPTION
Use the animated background that comes with this theme if the profile has no background equipped, and make sure it works if pinned background is enabled (`FPinnedBackground` now needs to depend on `FCustomStyle` as well in case a custom background is set).