### PR TITLE
Fix storefront more content section node selector

### DIFF
--- a/src/js/Content/Features/Common/FEarlyAccess.ts
+++ b/src/js/Content/Features/Common/FEarlyAccess.ts
@@ -20,7 +20,7 @@ const storeSelectors = [
     ".home_area_spotlight", // Special Offers, specials/
     ".curator_giant_capsule", // Curator Recommendations
     ".home_content_item",
-    ".home_content.single",
+    ".home_content.single > .gamelink",
     ".highlighted_app_header", // curators/
     "#curator_avatar_image", // Header image on dlc pages
     ".curator_featured a", // Featured items on curator, developer, publisher, franchise, dlc etc. pages
@@ -164,7 +164,7 @@ export default class FEarlyAccess extends Feature {
         ".home_area_spotlight", // Special Offers, specials/
         ".curator_giant_capsule", // Curator Recommendations
         ".home_content_item",
-        ".home_content.single",
+        ".home_content.single > .gamelink",
         ".highlighted_app_header", // curators/
         "#curator_avatar_image", // Header image on dlc pages
         ".curator_featured a", // Featured items on curator, developer, publisher, franchise, dlc etc. pages

--- a/src/js/Content/Features/Common/FHighlightsTags.js
+++ b/src/js/Content/Features/Common/FHighlightsTags.js
@@ -402,7 +402,7 @@ FHighlightsTags._selector = [
     "a.game_area_dlc_row", // DLC on app pages
     "a.small_cap", // Featured storefront items and "recommended" section on app pages
     ".home_content_item", // Small items under "Keep scrolling for more recommendations"
-    ".home_content.single", // Big items under "Keep scrolling for more recommendations"
+    ".home_content.single > .gamelink", // Big items under "Keep scrolling for more recommendations"
     ".home_area_spotlight", // "Special offers" big items
     "a.search_result_row", // Search result rows
     "a.match", // Search suggestions rows

--- a/src/js/Content/Features/Store/Storefront/CStoreFront.js
+++ b/src/js/Content/Features/Store/Storefront/CStoreFront.js
@@ -69,7 +69,7 @@ export class CStoreFront extends CStoreBase {
                 for (const {addedNodes} of mutations) {
                     for (const node of addedNodes) {
                         if (!(node instanceof Element)) { continue; }
-                        const nodes = node.querySelectorAll(".home_content_item, .home_content.single");
+                        const nodes = node.querySelectorAll(".home_content_item, .home_content.single > .gamelink");
                         this.decorateStoreCapsules(nodes);
                     }
                 }


### PR DESCRIPTION
Avoid wrongly using the appid of the `.home_content_reason` node for highlights / EA banners.