### PR TITLE
Fix extra links not showing up on package (`/sub/`) pages

### DIFF
--- a/src/js/Content/Features/Store/Common/FExtraLinksCommon.ts
+++ b/src/js/Content/Features/Store/Common/FExtraLinksCommon.ts
@@ -15,7 +15,7 @@ export default class FExtraLinksCommon extends Feature<CSub|CBundle> {
         if (this.context.type === ContextType.SUB) {
             type = "sub";
             gameid = (<CSub>(this.context)).subid;
-            target = document.querySelector(".share")?.parentElement ?? null;
+            target = document.querySelector(".rightcol.game_meta_data");
         } else {
             type = "bundle";
             gameid = (<CBundle>(this.context)).bundleid;


### PR DESCRIPTION
This should fix #2103.

Seems like Valve removed the .share box in November 2024 that AS was relying on here.
It still was there in October 2024 based on this archived page: `https://web.archive.org/web/20241018214631/http://store.steampowered.com/sub/469/`