### PR TITLE
Fix the “See more on SteamPeek” URL

### DIFF
--- a/src/js/Content/Features/Store/App/FSteamPeek.svelte
+++ b/src/js/Content/Features/Store/App/FSteamPeek.svelte
@@ -72,7 +72,7 @@
         <header>
             <div>Steampeek</div>
 
-            <a href="https://steampeek.hu/app/{appid}">{L(__moreOnSteampeek)}</a>
+            <a href="https://steampeek.hu/?appid={appid}">{L(__moreOnSteampeek)}</a>
         </header>
 
         <ul>


### PR DESCRIPTION
The current URL doesn't work anymore – it opens the 404 Not Found page.