### PR TITLE
Add ITAD price hover popup to cart page

### DIFF
--- a/src/js/Content/Features/Store/Cart/CCart.ts
+++ b/src/js/Content/Features/Store/Cart/CCart.ts
@@ -1,4 +1,5 @@
 import FCartHistoryLink from "./FCartHistoryLink";
+import FCartITADPrices from "./FCartITADPrices";
 import Context, {type ContextParams} from "@Content/Modules/Context/Context";
 import ContextType from "@Content/Modules/Context/ContextType";
 
@@ -8,6 +9,7 @@ export default class CCart extends Context {
 
         super(params, ContextType.CART, [
             FCartHistoryLink,
+            FCartITADPrices,
         ]);
     }
 }

--- a/src/js/Content/Features/Store/Cart/CartITADPricesPopup.svelte
+++ b/src/js/Content/Features/Store/Cart/CartITADPricesPopup.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+    import PriceWithAlt from "@Content/Modules/Prices/PriceWithAlt.svelte";
+    import type {TPriceOverview} from "@Background/Modules/AugmentedSteam/_types";
+    import {
+        __pricing_historicalLow,
+        __pricing_lowestPrice,
+        __pricing_store,
+        __pricing_withVoucher,
+        __pricing_bundleCount,
+        __pricing_bundled
+    } from "@Strings/_strings";
+    import {L} from "@Core/Localization/Localization";
+    import HTML from "@Core/Html/Html";
+    import external from "@Content/externalLink";
+
+    export let data: TPriceOverview;
+    export let priceNode: Element;
+
+    let currentDrms: string[] = [];
+
+    if (data.current) {
+        currentDrms = data.current.drm
+            .filter(d => d.id !== 61) // 61 = Steam
+            .map(d => d.name);
+    }
+
+    let container: HTMLElement;
+
+    // Add hover cursor styling to the price node
+    priceNode.classList.add("es_itad_onmouse");
+
+    priceNode.addEventListener("mouseenter", () => {
+        const rects = priceNode.getBoundingClientRect();
+        container.style.display = "block";
+        container.style.top = `${rects.bottom + window.scrollY + 5}px`;
+        container.style.left = `${rects.left + window.scrollX}px`;
+
+        // Ensure popup doesn't go off-screen to the right
+        requestAnimationFrame(() => {
+            const containerRect = container.getBoundingClientRect();
+            if (containerRect.right > window.innerWidth) {
+                container.style.left = `${window.innerWidth - containerRect.width - 10}px`;
+            }
+        });
+    });
+
+    priceNode.addEventListener("mouseleave", () => {
+        container.style.display = "none";
+    });
+</script>
+
+
+<div class="es_cart_itad_popup" bind:this={container}>
+    <div class="es_cart_itad_arrow"></div>
+
+    {#if data.current}
+        <div class="es_cart_itad_row">
+            <a href={data.urls.info} use:external class="es_cart_itad_label">{L(__pricing_lowestPrice)}</a>
+            <span class="es_cart_itad_price">
+                <PriceWithAlt price={data.current.price} />
+            </span>
+        </div>
+        <div class="es_cart_itad_row es_cart_itad_detail">
+            <a href={data.current.url} use:external>
+                {#if data.current.cut > 0}
+                    <span class="es_cart_itad_cut">-{data.current.cut}%</span>
+                {/if}
+
+                {#if data.current.voucher}
+                    <span class="es_cart_itad_voucher">{L(__pricing_withVoucher, {"voucher": data.current.voucher})}</span>
+                {/if}
+
+                {@html L(__pricing_store, {"store": HTML.escape(data.current.shop.name)})}
+                {#if currentDrms.length > 0}
+                    <span class="es_cart_itad_drm">({currentDrms.join(", ")})</span>
+                {/if}
+            </a>
+        </div>
+    {/if}
+
+    {#if data.lowest}
+        <div class="es_cart_itad_row">
+            <a href={data.urls.history} use:external class="es_cart_itad_label">{L(__pricing_historicalLow)}</a>
+            <span class="es_cart_itad_price">
+                <PriceWithAlt price={data.lowest.price} />
+            </span>
+        </div>
+        <div class="es_cart_itad_row es_cart_itad_detail">
+            {#if data.lowest.cut > 0}
+                <span class="es_cart_itad_cut">-{data.lowest.cut}%</span>
+            {/if}
+            {@html L(__pricing_store, {"store": HTML.escape(data.lowest.shop.name)})}
+            <span class="es_cart_itad_date">{new Date(data.lowest.timestamp).toLocaleDateString()}</span>
+        </div>
+    {/if}
+
+    {#if data.bundled}
+        <div class="es_cart_itad_row">
+            <a href={data.urls.info} use:external class="es_cart_itad_label">{L(__pricing_bundled)}</a>
+            <span class="es_cart_itad_bundled">{L(__pricing_bundleCount, {"count": data.bundled})}</span>
+        </div>
+    {/if}
+</div>
+
+
+<style>
+    /**
+     * Styles for parent container
+     */
+    :global(.es_itad_onmouse) {
+        cursor: help;
+    }
+
+    :global(.es_itad_pricing_hover) {
+        position: relative;
+    }
+
+    /**
+     * Popup styles
+     */
+    .es_cart_itad_popup {
+        display: none;
+        position: absolute;
+        z-index: 1000;
+        background: linear-gradient(135deg, #1b2838 0%, #2a475e 100%);
+        padding: 10px 12px;
+        border-radius: 4px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+        border: 1px solid #16202d;
+        min-width: 250px;
+        max-width: 350px;
+        font-size: 12px;
+        color: #acb2b8;
+        pointer-events: none;
+    }
+
+    .es_cart_itad_popup::before {
+        content: "";
+        position: absolute;
+        width: 24px;
+        height: 24px;
+        background-image: url("extension://img/itad.png");
+        background-size: contain;
+        background-repeat: no-repeat;
+        top: 8px;
+        right: 8px;
+        opacity: 0.6;
+    }
+
+    .es_cart_itad_arrow {
+        position: absolute;
+        top: -8px;
+        left: 20px;
+        width: 0;
+        height: 0;
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        border-bottom: 8px solid #2a475e;
+    }
+
+    .es_cart_itad_row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        margin-bottom: 4px;
+    }
+
+    .es_cart_itad_row:last-child {
+        margin-bottom: 0;
+    }
+
+    .es_cart_itad_label {
+        color: #67c1f5;
+        text-decoration: none;
+        white-space: nowrap;
+    }
+
+    .es_cart_itad_label:hover {
+        color: #fff;
+        text-decoration: underline;
+    }
+
+    .es_cart_itad_price {
+        color: #acdbf5;
+        font-weight: bold;
+        margin-left: auto;
+    }
+
+    .es_cart_itad_detail {
+        font-size: 11px;
+        color: #8f98a0;
+        padding-left: 10px;
+        margin-bottom: 8px;
+    }
+
+    .es_cart_itad_detail a {
+        color: #8f98a0;
+        text-decoration: none;
+    }
+
+    .es_cart_itad_detail a:hover {
+        color: #fff;
+    }
+
+    .es_cart_itad_cut {
+        color: #a4d007;
+        font-weight: bold;
+        margin-right: 4px;
+    }
+
+    .es_cart_itad_voucher {
+        color: #e5c07b;
+        margin-right: 4px;
+    }
+
+    .es_cart_itad_drm {
+        text-transform: uppercase;
+        color: #626366;
+        font-size: 10px;
+    }
+
+    .es_cart_itad_date {
+        color: #626366;
+        margin-left: 4px;
+    }
+
+    .es_cart_itad_bundled {
+        color: #acdbf5;
+        margin-left: auto;
+    }
+</style>

--- a/src/js/Content/Features/Store/Cart/FCartITADPrices.ts
+++ b/src/js/Content/Features/Store/Cart/FCartITADPrices.ts
@@ -1,0 +1,185 @@
+import Feature from "@Content/Modules/Context/Feature";
+import type CCart from "@Content/Features/Store/Cart/CCart";
+import Settings from "@Options/Data/Settings";
+import Prices from "@Content/Modules/Prices/Prices";
+import type {TPriceOverview} from "@Background/Modules/AugmentedSteam/_types";
+import CartITADPricesPopup from "./CartITADPricesPopup.svelte";
+
+interface CartItem {
+    appid: number;
+    priceNode: HTMLElement;
+}
+
+export default class FCartITADPrices extends Feature<CCart> {
+
+    override checkPrerequisites(): boolean {
+        return Settings.showlowestprice;
+    }
+
+    override async apply(): Promise<void> {
+        const root = document.querySelector('[data-featuretarget="react-root"]');
+        if (!root) { return; }
+
+        // Use MutationObserver to wait for cart content to load
+        const observer = new MutationObserver(async () => {
+            await this.processCartItems();
+        });
+
+        observer.observe(root, {"childList": true, "subtree": true});
+
+        // Also process immediately in case content is already loaded
+        await this.processCartItems();
+    }
+
+    private processedItems: WeakSet<Element> = new WeakSet();
+
+    private async processCartItems(): Promise<void> {
+        // Find cart line items - look for elements that contain app links
+        const cartItems = this.findCartItems();
+
+        if (cartItems.length === 0) { return; }
+
+        // Collect all appids for batch fetching
+        const appids = cartItems.map(item => item.appid);
+        const uniqueAppids = [...new Set(appids)];
+
+        // Fetch ITAD prices for all items
+        const prices = new Prices(this.context.user);
+        const priceData = await prices.load({ apps: uniqueAppids });
+
+        // Create price lookup map
+        const priceMap = new Map<number, TPriceOverview>();
+        for (const { type, id, data } of priceData.prices) {
+            if (type === "app") {
+                priceMap.set(id, data);
+            }
+        }
+
+        // Attach hover popups to each cart item's price
+        for (const item of cartItems) {
+            const data = priceMap.get(item.appid);
+            if (data && (data.current || data.lowest)) {
+                this.attachPricePopup(item.priceNode, data);
+            }
+        }
+    }
+
+    private findCartItems(): CartItem[] {
+        const items: CartItem[] = [];
+
+        // Look for cart row elements - Steam's React cart uses different structures
+        // Find elements that link to app pages
+        const appLinks = document.querySelectorAll<HTMLAnchorElement>('a[href*="/app/"]');
+
+        for (const link of appLinks) {
+            // Skip if already processed
+            if (this.processedItems.has(link)) { continue; }
+
+            // Extract appid from link
+            const match = link.href.match(/\/app\/(\d+)/);
+            if (!match || !match[1]) { continue; }
+
+            const appid = parseInt(match[1], 10);
+
+            // Find the associated price element
+            // Walk up to find the cart item container, then find the price within it
+            const cartItemContainer = this.findCartItemContainer(link);
+            if (!cartItemContainer) { continue; }
+
+            const priceNode = this.findPriceNode(cartItemContainer);
+            if (!priceNode) { continue; }
+
+            // Skip if this price node was already processed
+            if (this.processedItems.has(priceNode)) { continue; }
+
+            this.processedItems.add(link);
+            this.processedItems.add(priceNode);
+
+            items.push({ appid, priceNode });
+        }
+
+        return items;
+    }
+
+    private findCartItemContainer(element: HTMLElement): HTMLElement | null {
+        // Walk up the DOM to find the cart item container
+        let current: HTMLElement | null = element;
+        let depth = 0;
+        const maxDepth = 10;
+
+        while (current && depth < maxDepth) {
+            // Look for common cart item patterns
+            // Check if this element contains both a link and a price-like element
+            const hasPrice = current.querySelector('[class*="price" i], [class*="Price"]');
+            const hasImage = current.querySelector('img');
+
+            if (hasPrice && hasImage) {
+                return current;
+            }
+
+            // Also check for specific class patterns Steam might use
+            if (current.className && (
+                current.className.includes('CartRow') ||
+                current.className.includes('cart_item') ||
+                current.className.includes('CartItem')
+            )) {
+                return current;
+            }
+
+            current = current.parentElement;
+            depth++;
+        }
+
+        return null;
+    }
+
+    private findPriceNode(container: HTMLElement): HTMLElement | null {
+        // Look for price elements within the container
+        // Steam typically uses elements with "price" in the class name
+        const selectors = [
+            '[class*="ItemPriceBox"]',
+            '[class*="StoreSalePrice"]',
+            '[class*="Price"]:not([class*="PriceBox"])',
+            '[class*="price"]',
+        ];
+
+        for (const selector of selectors) {
+            const priceEl = container.querySelector<HTMLElement>(selector);
+            if (priceEl) {
+                // Make sure it looks like a price (contains numbers and currency symbols)
+                const text = priceEl.textContent || "";
+                if (/[\d.,]+/.test(text) && /[$€£¥₽₴₩₹R\$]|USD|EUR|GBP|Free/i.test(text)) {
+                    return priceEl;
+                }
+            }
+        }
+
+        // Fallback: look for any element containing price-like text
+        const allElements = container.querySelectorAll('*');
+        for (const el of allElements) {
+            if (el.children.length === 0) { // leaf nodes only
+                const text = el.textContent || "";
+                if (/^\s*[$€£¥₽₴₩₹R\$]?\s*[\d.,]+\s*[$€£¥₽₴₩₹]?\s*$/.test(text) ||
+                    /Free/i.test(text)) {
+                    return el as HTMLElement;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private attachPricePopup(priceNode: HTMLElement, data: TPriceOverview): void {
+        // Add hover styling
+        priceNode.classList.add("es_itad_pricing_hover");
+
+        // Create the popup component
+        new CartITADPricesPopup({
+            target: document.body,
+            props: {
+                data,
+                priceNode
+            }
+        });
+    }
+}


### PR DESCRIPTION
Add feature to show IsThereAnyDeal lowest prices when hovering over item prices in the shopping cart. This brings the same ITAD price comparison functionality that exists on store pages to the cart.

- FCartITADPrices.ts: Feature that finds cart items, extracts appids, fetches ITAD prices, and attaches hover handlers to price elements
- CartITADPricesPopup.svelte: Svelte component for the hover popup showing current lowest price, historical low, and bundle info