### PR TITLE
fix: Use term search fallback for developers with special characters

### DIFF
--- a/src/js/Content/Features/Store/App/FReplaceDevPubLinks.ts
+++ b/src/js/Content/Features/Store/App/FReplaceDevPubLinks.ts
@@ -42,7 +42,10 @@ export default class FReplaceDevPubLinks extends Feature<CApp> {
                 continue;
             }
 
-            node.href = `https://store.steampowered.com/search/?${type}=${encodeURIComponent(node.textContent!)}`;
+            const name = node.textContent!;
+            const searchParam = name.includes('&') ? 'term' : type;
+            node.href = `https://store.steampowered.com/search/?${searchParam}=${encodeURIComponent(name)}`;
+            
             HTML.afterEnd(node, ` <span class="as-homepage">(<a href="${homepageLink.href}">${L(__options_homepage)}</a>)</span>`);
         }
 


### PR DESCRIPTION
### Summary
Fixes an issue where clicking on a Developer or Publisher link (e.g., "Draknek & Friends") resulted in 0 search results due to strict URL encoding of special characters like `&`.

### The Problem
Augmented Steam generates search links using `?developer=` or `?publisher=`. Steam's search engine fails to strictly match these fields when the query string contains encoded characters (e.g., `%26` for `&`).

### The Solution
Updated `FReplaceDevPubLinks.ts` to check the developer/publisher name for special characters.
- If an ampersand (`&`) is detected, the search parameter switches to `?term=` (General Search), which handles special characters robustly.
- Standard names continue to use the specific `?developer=` or `?publisher=` filters.

### Verification
- Tested with "Draknek & Friends": Link now correctly finds all games (verified via `?term=` fallback).
- Tested with standard names: Links continue to work as expected.

Closes #2237