### PR TITLE
Removed unwanted text getting added under “Downloadable Content Details”

### DIFF
--- a/src/js/Content/Features/Store/App/FDLCInfo.svelte
+++ b/src/js/Content/Features/Store/App/FDLCInfo.svelte
@@ -11,7 +11,7 @@
 <div class="block es_dlc_info">
     <div class="block_content">
         <div class="block_content_inner">
-            <div class="details_block">`;
+            <div class="details_block">
 
                 {#each dlcInfo as item}
                     <div class="game_area_details_specs">


### PR DESCRIPTION
`https://store.steampowered.com/app/378648/The_Witcher_3_Wild_Hunt__Blood_and_Wine/`

<img width="423" height="659" alt="obraz" src="https://github.com/user-attachments/assets/ce25f812-3d75-416d-abb1-eee6df2b1e3f" />