### PR TITLE
Increase market listing delay from 2 seconds to 3 seconds

### DIFF
--- a/src/js/Content/Features/Community/MarketHome/FMarketLowestPrice.ts
+++ b/src/js/Content/Features/Community/MarketHome/FMarketLowestPrice.ts
@@ -13,7 +13,7 @@ import Price from "@Content/Modules/Currency/Price";
 export default class FMarketLowestPrice extends Feature<CMarketHome> {
 
     private _loadedMarketPrices: Record<string, string> = {};
-    private _delayMs = 2000; // Delay to put between requests in attempt to avoid 429s
+    private _delayMs = 3000; // Delay to put between requests in attempt to avoid 429s
     private _delay = false; // Whether to put a delay between requests
     private _timeout = false; // Whether the user has been timed-out
 


### PR DESCRIPTION
With the lowest price market listing delay set to 2 seconds, the rate limit is hit after about 20 prices are loaded and no further prices are loaded. With the delay set to 3 seconds, prices seem to keep loading indefinitely. This is based on several tests of both delay settings with ~100 items listed in the market. 