### PR TITLE
Fix invalid currency display

### DIFF
--- a/src/js/Content/Modules/Currency/CurrencyManager.ts
+++ b/src/js/Content/Modules/Currency/CurrencyManager.ts
@@ -63,8 +63,21 @@ export default class CurrencyManager {
         return null;
     }
 
+    private static _getCurrencyCodeFromAppConfig(): string|null {
+        const configNode: HTMLElement|null = document.querySelector("#application_config");
+
+        if (!configNode?.dataset.store_user_config) {
+            return null;
+        }
+
+        const storeUserConfig = JSON.parse(configNode.dataset.store_user_config);
+        const currencyId = storeUserConfig?.accountcart?.cart?.subtotal?.currency_code;
+
+        return currencyId ? this.currencyIdToCode(currencyId) : null;
+    }
+
     private static async _getStoreCurrency(): Promise<string> {
-        let currency = this._getCurrencyCodeFromDom() ?? this._getCurrencyCodeFromWallet();
+        let currency = this._getCurrencyCodeFromDom() ?? this._getCurrencyCodeFromWallet() ?? this._getCurrencyCodeFromAppConfig();
         if (currency) {
             return currency;
         }


### PR DESCRIPTION
### Summary
Fixes an issue where USD is incorrectly displayed as the store currency in certain scenarios:
<img width="1518" height="800" alt="image" src="https://github.com/user-attachments/assets/5d053440-f1b8-44cb-bff9-e507994bc9e3" />

Notice that individual items are correctly displayed using the ₱ currency, but the savings value is still shown in $.

### The Problem
`CurrencyManager` can fail to resolve the correct currency code when both `_getCurrencyCodeFromDom()` and `_getCurrencyCodeFromWallet()` return `null`.

When this happens `CurrencyManager` falls back to USD, even when the user is on a different store region.

### The Solution
Introduced a new fallback method `_getCurrencyCodeFromAppConfig()` that extracts the currency code from the `#application_config` DOM element. This element contains serialized metadata, including user/session-specific store information such as the cart and its `currency_code`.

<img width="1516" height="812" alt="image" src="https://github.com/user-attachments/assets/80236297-b05d-4fba-88ea-d25acb1f4618" />
