### PR TITLE
Fix Steam date locale formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "augmented-steam",
   "scripts": {
+    "test": "node test/language-locale.test.mjs",
     "build": "node scripts/build.mjs",
     "update-locales": "node scripts/locales.mjs download",
     "compile-locales": "node scripts/locales.mjs compile",

--- a/src/js/Content/Features/Store/App/FPurchaseDate.ts
+++ b/src/js/Content/Features/Store/App/FPurchaseDate.ts
@@ -33,7 +33,7 @@ export default class FPurchaseDate extends Feature<CApp> {
                 date: datetime.toLocaleString({
                     dateStyle: "medium"
                 }, {
-                    locale: this.context.language?.code ?? undefined
+                    locale: this.context.language?.locale ?? undefined
                 })
             })})`;
         }

--- a/src/js/Content/Features/Store/App/FReleaseCountdown.ts
+++ b/src/js/Content/Features/Store/App/FReleaseCountdown.ts
@@ -46,7 +46,7 @@ export default class FReleaseCountdown extends Feature<CApp> {
                     dateStyle: "medium",
                     timeStyle: "short"
                 }, {
-                    locale: this.context.language?.code ?? undefined
+                    locale: this.context.language?.locale ?? undefined
                 })
                 const str = ` (${date})`;
 

--- a/src/js/Core/Localization/Language.ts
+++ b/src/js/Core/Localization/Language.ts
@@ -32,12 +32,20 @@ export default class Language {
         "vietnamese": "vi",
     };
 
+    public static readonly localeMap: Record<string, string> = {
+        ...Language.map,
+        "thai": "th-TH-u-ca-gregory",
+        "ukrainian": "uk",
+    };
+
     private readonly _name: string;
     private readonly _code: string|null;
+    private readonly _locale: string|null;
 
     constructor(language: string) {
         this._name = language;
         this._code = Language.map[language] ?? null;
+        this._locale = Language.localeMap[language] ?? this._code;
         // TODO should we throw when there is unsupported language?
     }
 
@@ -49,8 +57,11 @@ export default class Language {
         return this._code;
     }
 
+    get locale(): string|null {
+        return this._locale;
+    }
+
     isOneOf(...languages: string[]) {
         return languages.includes(this._name);
     }
 }
-

--- a/test/language-locale.test.mjs
+++ b/test/language-locale.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {pathToFileURL} from "node:url";
+import {build} from "esbuild";
+import {DateTime} from "luxon";
+
+async function importLanguage() {
+    const result = await build({
+        entryPoints: ["src/js/Core/Localization/Language.ts"],
+        bundle: true,
+        format: "esm",
+        platform: "node",
+        write: false
+    });
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "as-language-"));
+    const modulePath = path.join(tempDir, "Language.mjs");
+    await fs.writeFile(modulePath, result.outputFiles[0].text);
+    return import(pathToFileURL(modulePath));
+}
+
+const {default: Language} = await importLanguage();
+
+const ukrainian = new Language("ukrainian");
+assert.equal(ukrainian.code, "ua");
+assert.equal(ukrainian.locale, "uk");
+
+const thai = new Language("thai");
+assert.equal(thai.code, "th");
+assert.equal(thai.locale, "th-TH-u-ca-gregory");
+
+const formattedThaiDate = DateTime.fromObject({
+    year: 2026,
+    month: 1,
+    day: 23
+}).toLocaleString({dateStyle: "medium"}, {locale: thai.locale});
+
+assert.match(formattedThaiDate, /2026/);
+assert.doesNotMatch(formattedThaiDate, /2569/);


### PR DESCRIPTION
Summary
- Add a separate browser date locale on Language while keeping the existing extension language code for localization files.
- Use that locale for exact release and purchase dates so Ukrainian formats use uk and Thai dates stay Gregorian.
- Add a focused Node regression test for the locale mapping.

Tests
- npm test
- npm run check
- npm run build
- git diff --check

Related to #2327