### PR TITLE
Fix hidden apps in the wishlist stats pop-up

### DIFF
--- a/src/js/Content/Features/Store/Wishlist/Components/WishlistStats.svelte
+++ b/src/js/Content/Features/Store/Wishlist/Components/WishlistStats.svelte
@@ -81,7 +81,7 @@
             for (const item of page.storeItems) {
                 const option = item.bestPurchaseOption;
                 if (!option) {
-                    if (item.unlisted) {
+                    if (!item.visible) {
                         unlistedApps.push(item);
                     } else {
                         noPriceCount++;


### PR DESCRIPTION
Currently, the `Hidden apps` pop-up appears to list games that are no longer available for purchase but whose Steam store pages are still visible.

I believe the pop-up should instead only include games whose store pages are no longer visible (i.e. items that appear as `(unavailable item)` on the wishlist).

For example, `Marvel's Guardians of the Galaxy: The Telltale Series` (`https://store.steampowered.com/app/579950/Marvels_Guardians_of_the_Galaxy_The_Telltale_Series/`) is currently included in the `Hidden apps` list even though its store page is still accessible (`visible: true`).

With this change, that game is no longer treated as hidden. Instead, games whose store pages are actually unavailable (for example, `Deadpool`, app 224060, which has `visible: false`) are included in the list.

<details>
<summary>Guardians of the Galaxy JSON</summary>

```
    {
        "includedTypes": [],
        "includedAppids": [],
        "contentDescriptorids": [],
        "tagids": [],
        "tags": [],
        "purchaseOptions": [],
        "accessories": [],
        "invalidPurchaseOptions": [],
        "supportedLanguages": [],
        "links": [],
        "itemType": 0,
        "id": 579950,
        "success": 1,
        "visible": true,
        "name": "Marvel's Guardians of the Galaxy: The Telltale Series",
        "storeUrlPath": "app/579950/Marvels_Guardians_of_the_Galaxy_The_Telltale_Series",
        "appid": 579950,
        "type": 0,
        "categories": {
            "supportedPlayerCategoryids": [
                2
            ],
            "featureCategoryids": [
                22,
                62
            ],
            "controllerCategoryids": [
                28
            ]
        },
        "basicInfo": {
            "publishers": [
                {
                    "name": "Telltale Games",
                    "creatorClanAccountId": 21416
                }
            ],
            "developers": [
                {
                    "name": "Telltale Games",
                    "creatorClanAccountId": 21416
                }
            ],
            "franchises": [],
            "shortDescription": "From Earth to the Milano to Knowhere and beyond, and set to the beat of awesome music, this five-part episodic series puts you in the rocket-powered boots of Star-Lord in an original Guardians adventure."
        },
        "unlisted": true
    }
```
</details>

<details>
<summary>Deadpool JSON</summary>

```
    {
        "includedTypes": [],
        "includedAppids": [],
        "contentDescriptorids": [],
        "tagids": [],
        "tags": [],
        "purchaseOptions": [],
        "accessories": [],
        "invalidPurchaseOptions": [],
        "supportedLanguages": [],
        "links": [],
        "itemType": 0,
        "id": 224060,
        "success": 15,
        "visible": false,
        "name": "",
        "storeUrlPath": "app/224060/",
        "appid": 224060
    }
```
</details>

EDIT: Probably the variable names should be updated too. For example: `unlistedApps` → `hiddenApps`.
This is how the code looked for this before the rewrite: https://github.com/IsThereAnyDeal/AugmentedSteam/blob/v4.1.2/src/js/Content/Features/Store/Wishlist/FWishlistStats.ts