### PR TITLE
Hide empty HowLongToBeat sections

### DIFF
--- a/src/js/Content/Features/Store/App/FHowLongToBeat.ts
+++ b/src/js/Content/Features/Store/App/FHowLongToBeat.ts
@@ -14,7 +14,11 @@ export default class FHowLongToBeat extends Feature<CApp> {
         }
 
         const result = await this.context.data;
-        if (!result || !result.hltb) {
+        if (
+            !result?.hltb
+            || [result.hltb.story, result.hltb.extras, result.hltb.complete]
+                .every(duration => duration === null)
+        ) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

- hide the HowLongToBeat section when story, extras, and completion times are all unavailable
- use explicit `null` checks so a valid duration of `0` remains visible

Fixes #2352.

## Testing

- `npm run check` (0 errors, 0 warnings)
- `npm run build`

## AI assistance

OpenAI Codex assisted with issue discovery, implementation, and validation. I reviewed the change and test results.
