### PR TITLE
Fix: Restored storefront highlighting and Early Access banners after Steam markup changes

### DIFF
--- a/src/js/Content/Features/Store/Storefront/CStoreFront.ts
+++ b/src/js/Content/Features/Store/Storefront/CStoreFront.ts
@@ -99,7 +99,8 @@ export default class CStoreFront extends CStoreBase {
                     if (addedNodes.length > 1) {
                         // @ts-ignore
                         const nodes: HTMLElement[] = Array.from(addedNodes)
-                            .filter(el => el instanceof HTMLElement && el.classList.contains("tab_item"));
+                            .filter(el => el instanceof HTMLElement
+                                && (el.classList.contains("tab_item") || el.classList.contains("tab_row_item")));
 
                         this.decorateStoreCapsules(nodes);
                     }

--- a/src/js/Content/Modules/EarlyAccess/EarlyAccess.svelte
+++ b/src/js/Content/Modules/EarlyAccess/EarlyAccess.svelte
@@ -43,6 +43,25 @@
         width: 100%;
     }
 
+    /*
+     * The component moves the capsule's own image into .es_overlay_container, which drops
+     * any of Steam's rules that positioned that image through a child combinator. The rule
+     * above compensates for that on .store_capsule, whose image Steam positions absolutely
+     * inside a percentage-padding ratio box.
+     *
+     * A .sale_capsule on its own is laid out the other way round: its image is in flow and
+     * gives the capsule its height, so the container has to stay in flow too or the capsule
+     * collapses to the height of its price bar. The daily deals carry both classes and need
+     * the .store_capsule treatment, hence the :not().
+     */
+    :global(.sale_capsule:not(.store_capsule)) .es_overlay_container {
+        position: relative;
+        display: inherit;
+    }
+    :global(.sale_capsule:not(.store_capsule)) .es_overlay_container > :global(img) {
+        width: 100%;
+    }
+
     .es_overlay,
     .es_overlay img {
         position: absolute;

--- a/src/js/Content/Modules/EarlyAccess/EarlyAccessUtils.ts
+++ b/src/js/Content/Modules/EarlyAccess/EarlyAccessUtils.ts
@@ -9,10 +9,12 @@ export default class EarlyAccessUtils {
 
     // TODO support React-based sales pages, curator lists, etc.
     private static readonly storeSelectors = [
-        ".tab_item", // Item rows on storefront
+        ".tab_item", // Item rows on storefront (pre-2026 markup)
+        ".tab_row_item", // Item rows on storefront
         ".newonsteam_headercap", // explore/new
         ".comingsoon_headercap", // explore/upcoming
         ".store_capsule",
+        ".sale_capsule", // "Discounts & Events" carousel on the storefront
         ".dailydeal_ctn",
         ".special.special_img_ctn", // explore/new, cart/
         /*

--- a/src/js/Content/Modules/Highlights/HighlightsTagsUtils.ts
+++ b/src/js/Content/Modules/Highlights/HighlightsTagsUtils.ts
@@ -38,10 +38,12 @@ export default class HighlightsTagsUtils {
 
     // Note: select the node which has DS info, and traverse later when highlighting if needed
     private static readonly _selector = [
-        ".tab_item", // Item rows on storefront
+        ".tab_item", // Item rows on storefront (pre-2026 markup)
+        ".tab_row_item", // Item rows on storefront
         ".newonsteam_headercap", // explore/new/
         ".comingsoon_headercap", // explore/upcoming/
         ".store_capsule",
+        ".sale_capsule", // "Discounts & Events" carousel on the storefront
         ".dailydeal_ctn",
         ".special.special_img_ctn", // explore/new, cart/
         ".special > .special_img_ctn",
@@ -65,6 +67,7 @@ export default class HighlightsTagsUtils {
         ".friendactivity_tab_row", // recommended/friendactivity/
         ".recommendation_app", // recommended/byfriends/
         ".recommendation_carousel_item",
+        ".community_recommendation_capsule", // Community Recommendations on the storefront
         ".app_header",
         ".friendplaytime_appheader",
     ].join(",");
@@ -246,8 +249,9 @@ export default class HighlightsTagsUtils {
                 container.classList.add("es_tags_short");
             }
 
-            if (node.classList.contains("tab_item")) {
-                node.querySelector(".tab_item_details")!.prepend(container);
+            if (node.classList.contains("tab_item") || node.classList.contains("tab_row_item")) {
+                // Steam replaced .tab_item_details with .tab_item_content
+                (node.querySelector(".tab_item_details") ?? node.querySelector(".tab_item_content"))!.prepend(container);
             } else if (node.classList.contains("store_main_capsule")) {
                 node.querySelector(".platforms")!.prepend(container);
             } else if (node.classList.contains("newonsteam_headercap") || node.classList.contains("comingsoon_headercap")) {
@@ -270,6 +274,8 @@ export default class HighlightsTagsUtils {
                 node.querySelector(".regular_price, .discount_block")!.append(container);
             } else if (node.classList.contains("recommendation_carousel_item")) {
                 node.querySelector(".buttons")!.before(container);
+            } else if (node.classList.contains("community_recommendation_capsule")) {
+                node.parentElement!.querySelector(".right_col")!.prepend(container);
             } else if (node.classList.contains("friendplaytime_game")) {
                 node.querySelector(".friendplaytime_buttons")!.before(container);
             }
@@ -334,7 +340,9 @@ export default class HighlightsTagsUtils {
         if (node.classList.contains("item")) {
             nodeToHighlight = node.querySelector<HTMLElement>(".info");
         } else if (node.classList.contains("home_area_spotlight")) {
-            nodeToHighlight = node.querySelector(".spotlight_content");
+            // Steam replaced .spotlight_content with .spotlight_bottom_ctn; support both
+            nodeToHighlight = node.querySelector(".spotlight_content")
+                ?? node.querySelector(".spotlight_bottom_ctn");
         } else if (node.classList.contains("special_img_ctn") && node.parentElement?.classList.contains("special")) {
             nodeToHighlight = node.parentElement;
         } else if (node.classList.contains("store_capsule")) {
@@ -354,6 +362,8 @@ export default class HighlightsTagsUtils {
             || node.classList.contains("game_capsule")
             || node.classList.contains("highlighted_app_header")
             || node.classList.contains("friendplaytime_appheader")
+            // the capsule <a> is fully covered by its image; the parent carries the visible area
+            || node.classList.contains("community_recommendation_capsule")
         ) {
             nodeToHighlight = node.parentNode as HTMLElement;
         }


### PR DESCRIPTION
Steam's big June update broke some of the waitlist/wishlist/etc highlighting. I took a look and couldn't figure it out myself back in June but I recently had some spare usage with Claude so I had it take a look. It was able to figure out the issues and it is looking good to me now when testing on Firefox.

Anyways, here is what Claude wanted me to paste in here which is way more informative than what I've got to say and likely way more useful haha:

---

Steam's storefront redesign renamed several capsule classes and removed a node
that Augmented Steam highlights. Because the highlight is applied with an
optional-chained `classList.add`, the failures were silent, so most of the
signed-in front page stopped being highlighted, tagged, or marked as Early
Access without any error being raised.

## Highlighting and tagging

- **`.sale_capsule` was unknown.** The "Discounts & Events" carousel renders its
  items as `.sale_capsule`. Only the legacy daily deals also carry
  `.store_capsule`, which is why exactly those kept working while everything
  else in the carousel went unstyled.
- **`.home_area_spotlight` no longer contains `.spotlight_content`.** The
  structure is now `.spotlight_img` + `.spotlight_bottom_ctn`, so
  `nodeToHighlight` was `null` and the highlight was dropped silently. The old
  node is still checked first, with the new one as a fallback.
- **`.tab_item` is now `.tab_row_item`,** and `.tab_item_details` is now
  `.tab_item_content`. `.tab_item` currently matches zero elements on the
  storefront. The selector, the tag container placement and the top sellers
  MutationObserver are all updated. This looks like the cause of the existing
  `// TODO Steam broke this section` note.
- **Added `.community_recommendation_capsule`.** Its `<a>` is fully covered by
  its own image, so the parent is highlighted instead, matching how the other
  image-only capsules are handled.

## Early Access

The Early Access selector list had gone stale in the same way, so no banner
appeared on the carousel capsules or the item rows. `.sale_capsule` and
`.tab_row_item` are added.

`.sale_capsule` needs its own overlay rule rather than reusing the
`.store_capsule` one. The component moves the capsule's own image into
`.es_overlay_container`, and these capsules take their height from that image,
so the container has to stay in flow — making it absolute collapses the capsule
to the height of its price bar and breaks the carousel grid. The rule is
declared after the `.store_capsule` one because the daily deals carry both
classes and the in-flow rule has to win. `.tab_row_item` needs no rule,
matching the `.tab_item` it replaces.

## Verification

Checked against a signed-in storefront with a connected ITAD account.

| Section | Before | After |
| --- | --- | --- |
| Discounts & Events carousel | 4 / 22 considered | 22 / 22 |
| Storefront item rows (5 tabs) | 0 / 45 | 45 / 45 |
| The Community Recommends | 0 / 10 | 10 / 10 |

Spot-checked that highlight *types* are right, not just that something was
painted: titles known to be on the ITAD waitlist come out green and match what
the same games get on their app pages, and titles not on it stay default.

Early Access: banners render on `.sale_capsule` and `.tab_row_item`, anchored to
each capsule's top left corner. Checked for layout regressions by comparing every
capsule carrying a banner against untouched capsules sharing its class signature
— heights and image offsets match in each case (`store_capsule+sale_capsule`
193px, `sale_capsule` 160-276px, `tab_row_item` 76px, image offset 0 throughout).

`npx tsc --noEmit` and `svelte-check` are both clean, and firefox, chrome and
edge all build.

## Deliberately not addressed

- **React-based sections** (Personal Calendar, `specials/`). These carry roughly
  50 items with `data-ds-appid` on the front page but their class names are
  build-generated hashes, so they need matching on the data attribute rather
  than on classes. That felt like a different change from these renames.
- **Tag placement for capsules.** `_addTag` has no branch for `.store_capsule`
  or `.sale_capsule`, so a tag is built and never inserted. That is pre-existing
  rather than something these changes introduce, and giving each capsule type a
  sensible insertion point seemed out of scope here. The `.tab_row_item` and
  `.community_recommendation_capsule` placements included above are written to
  match the surrounding code but have only been reasoned from the DOM, not seen
  rendered, since I highlight rather than tag.
  
  
  ---