### PR TITLE
Fix initialization on headerless Steam CEF pages

### DIFF
--- a/src/js/Content/Features/LegacyPage.ts
+++ b/src/js/Content/Features/LegacyPage.ts
@@ -13,7 +13,7 @@ import ITAD from "@Content/Modules/ITAD";
 export default class LegacyPage extends Page {
 
     override check(): boolean {
-        return !!document.getElementById("global_header");
+        return !!document.querySelector("#global_header, .responsive_page_frame.no_header");
     }
 
     protected override async getAppConfig(factory: AppConfigFactory): Promise<AppConfig> {

--- a/src/js/Content/Features/Page.ts
+++ b/src/js/Content/Features/Page.ts
@@ -53,12 +53,32 @@ export default abstract class Page {
     protected abstract getLanguage(factory: LanguageFactory): Promise<Language|null>;
     protected abstract getUser(factory: UserFactory): Promise<UserInterface>;
 
+    private async waitForCheck(timeout = 10000): Promise<boolean> {
+        if (this.check()) { return true; }
+
+        return new Promise(resolve => {
+            const observer = new MutationObserver(() => {
+                if (!this.check()) { return; }
+
+                window.clearTimeout(timeoutId);
+                observer.disconnect();
+                resolve(true);
+            });
+            const timeoutId = window.setTimeout(() => {
+                observer.disconnect();
+                resolve(false);
+            }, timeout);
+
+            observer.observe(document.documentElement, {childList: true, subtree: true});
+        });
+    }
+
     async run(): Promise<void> {
         if (document.querySelector("#as-menu")) {
             // already loaded
             return;
         }
-        if (!this.check()) { return; }
+        if (!await this.waitForCheck()) { return; }
 
         let language: Language|null;
         let user: UserInterface;

--- a/src/js/Content/Features/Store/App/PApp.ts
+++ b/src/js/Content/Features/Store/App/PApp.ts
@@ -6,4 +6,17 @@
 import CApp from "@Content/Features/Store/App/CApp";
 import StorePage from "@Content/Features/StorePage";
 
-(new StorePage(CApp)).run();
+const page = new StorePage(CApp);
+const selector = ".page_content_ctn > .page_content, #error_box";
+
+if (document.querySelector(selector)) {
+    page.run();
+} else {
+    const observer = new MutationObserver(() => {
+        if (!document.querySelector(selector)) { return; }
+
+        observer.disconnect();
+        page.run();
+    });
+    observer.observe(document.documentElement, {childList: true, subtree: true});
+}

--- a/src/js/Content/Modules/AugmentedSteam.ts
+++ b/src/js/Content/Modules/AugmentedSteam.ts
@@ -32,7 +32,11 @@ export default class AugmentedSteam {
         const target = document.querySelector(this.react
             ? "header nav + div"
             : "#global_action_menu"
-        )!;
+        );
+        if (!target) {
+            console.warn("Augmented Steam menu is unavailable on this page");
+            return;
+        }
 
         (new AugmentedSteamMenu({
             target,
@@ -116,7 +120,8 @@ export default class AugmentedSteam {
             target = document.querySelector("header ~ section");
             anchor = target?.firstElementChild ?? null;
         } else {
-            const header = document.querySelector("#global_header")!
+            const header = document.querySelector("#global_header");
+            if (!header) { return; }
             target = header.parentElement!;
             anchor = header.nextElementSibling!;
         }


### PR DESCRIPTION
## Problem

Steam's built-in browser can render store app pages without the legacy `#global_header` element. On these pages the content script may run before the client page has finished rendering, so the legacy page check fails and Augmented Steam does not initialize. Header-only widgets also assume that `#global_action_menu` and the legacy header are present.

## Changes

- wait for the page check to become true instead of returning immediately when the content script starts before the page shell is available
- treat Steam client's `.responsive_page_frame.no_header` as a valid legacy page container
- defer store app initialization until app details or an error box is present
- safely skip the menu and warnings when the page has no compatible legacy-header mount point

The existing behavior on regular Steam web pages is unchanged: when the legacy header is available, the normal menu and warnings are mounted as before.

## Testing

- `npx tsc --noEmit`
- `npm run build chrome -- --production`
- manually tested on a Steam client app page using Chromium 126

Related to #2307